### PR TITLE
velero server: log version and git SHA at startup

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -129,7 +129,7 @@ func NewCommand() *cobra.Command {
 
 			// Velero's DefaultLogger logs to stdout, so all is good there.
 			logger := logging.DefaultLogger(logLevel)
-			logger.Infof("Starting Velero server %s", buildinfo.FormattedGitSHA())
+			logger.Infof("Starting Velero server %s (%s)", buildinfo.Version, buildinfo.FormattedGitSHA())
 
 			// NOTE: the namespace flag is bound to velero's persistent flags when the root velero command
 			// creates the client Factory and binds the Factory's flags. We're not using a Factory here in


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

We're currently only logging the Git SHA in the server log on startup. Log both the version and the Git SHA.

(Note: prior to #1124 this was actually displaying the version, because `FormattedGitSHA()` actually showed a version number if it was a tagged commit. A/o 1124 this changed to actually displaying the git SHA. In any case, I'd like to show both)