### PR TITLE
Logging and misc cleanup

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -398,12 +398,7 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 		}
 	}
 
-	metadata, err := meta.Accessor(obj)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	pvFailureDomainZone := metadata.GetLabels()[zoneLabel]
+	pvFailureDomainZone := pv.Labels[zoneLabel]
 	if pvFailureDomainZone == "" {
 		log.Infof("label %q is not present on PersistentVolume", zoneLabel)
 	}
@@ -446,7 +441,7 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 
 	tags := map[string]string{
 		"velero.io/backup": ib.backupRequest.Name,
-		"velero.io/pv":     metadata.GetName(),
+		"velero.io/pv":     pv.Name,
 	}
 
 	log.Info("Getting volume information")
@@ -457,7 +452,7 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 	}
 
 	log.Info("Snapshotting PersistentVolume")
-	snapshot := volumeSnapshot(ib.backupRequest.Backup, metadata.GetName(), volumeID, volumeType, pvFailureDomainZone, location, iops)
+	snapshot := volumeSnapshot(ib.backupRequest.Backup, pv.Name, volumeID, volumeType, pvFailureDomainZone, location, iops)
 
 	var errs []error
 	snapshotID, err := blockStore.CreateSnapshot(snapshot.Spec.ProviderVolumeID, snapshot.Spec.VolumeAZ, tags)

--- a/pkg/controller/backup_sync_controller.go
+++ b/pkg/controller/backup_sync_controller.go
@@ -103,22 +103,22 @@ func shouldSync(location *velerov1api.BackupStorageLocation, now time.Time, back
 
 	revision, err := backupStore.GetRevision()
 	if err != nil {
-		log.WithError(err).Info("Error getting backup store's revision, syncing")
+		log.WithError(err).Debugf("Unable to get backup store's revision file, syncing (this is not an error if a v0.10+ backup has not yet been taken into this location)")
 		return true, ""
 	}
 	log = log.WithField("revision", revision)
 
 	if location.Status.LastSyncedTime.Add(time.Hour).Before(now) {
-		log.Infof("Backup location hasn't been synced in more than %s, syncing", time.Hour)
+		log.Debugf("Backup location hasn't been synced in more than %s, syncing", time.Hour)
 		return true, revision
 	}
 
 	if string(location.Status.LastSyncedRevision) != revision {
-		log.Info("Backup location hasn't been synced since its last modification, syncing")
+		log.Debugf("Backup location hasn't been synced since its last modification, syncing")
 		return true, revision
 	}
 
-	log.Debug("Backup location's contents haven't changed since last sync, not syncing")
+	log.Debugf("Backup location's contents haven't changed since last sync, not syncing")
 	return false, ""
 }
 
@@ -170,6 +170,7 @@ func (c *backupSyncController) run() {
 		if !ok {
 			continue
 		}
+		log.Infof("Syncing contents of backup store into cluster")
 
 		res, err := backupStore.ListBackups()
 		if err != nil {


### PR DESCRIPTION
Cleaned up a couple of logging issues that have come up over the last few days in Slack. Also noticed an unnecessary use of `meta.Accessor` while doing so, so removed it.