### PR TITLE
use restic stats instead of check to check repo existence

### DIFF
--- a/pkg/controller/restic_repository_controller.go
+++ b/pkg/controller/restic_repository_controller.go
@@ -162,10 +162,10 @@ func (c *resticRepositoryController) initializeRepo(req *v1.ResticRepository, lo
 	})
 }
 
-// ensureRepo first checks the repo, and returns if check passes. If it fails,
-// attempts to init the repo, and returns the result.
+// ensureRepo first tries to connect to the repo, and returns if it succeeds. If it fails,
+// it attempts to init the repo, and returns the result.
 func ensureRepo(repo *v1.ResticRepository, repoManager restic.RepositoryManager) error {
-	if repoManager.CheckRepo(repo) == nil {
+	if repoManager.ConnectToRepo(repo) == nil {
 		return nil
 	}
 

--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -84,6 +84,13 @@ func InitCommand(repoIdentifier string) *Command {
 	}
 }
 
+func StatsCommand(repoIdentifier string) *Command {
+	return &Command{
+		Command:        "stats",
+		RepoIdentifier: repoIdentifier,
+	}
+}
+
 func CheckCommand(repoIdentifier string) *Command {
 	return &Command{
 		Command:        "check",

--- a/pkg/restic/command_factory_test.go
+++ b/pkg/restic/command_factory_test.go
@@ -96,6 +96,13 @@ func TestInitCommand(t *testing.T) {
 	assert.Equal(t, "repo-id", c.RepoIdentifier)
 }
 
+func TestStatsCommand(t *testing.T) {
+	c := StatsCommand("repo-id")
+
+	assert.Equal(t, "stats", c.Command)
+	assert.Equal(t, "repo-id", c.RepoIdentifier)
+}
+
 func TestCheckCommand(t *testing.T) {
 	c := CheckCommand("repo-id")
 

--- a/pkg/restic/repository_manager.go
+++ b/pkg/restic/repository_manager.go
@@ -42,6 +42,12 @@ type RepositoryManager interface {
 	// InitRepo initializes a repo with the specified name and identifier.
 	InitRepo(repo *velerov1api.ResticRepository) error
 
+	// ConnectToRepo runs the 'restic stats' command against the
+	// specified repo, and returns an error if it fails. This is
+	// intended to be used to ensure that the repo exists/can be
+	// authenticated to.
+	ConnectToRepo(repo *velerov1api.ResticRepository) error
+
 	// CheckRepo checks the specified repo for errors.
 	CheckRepo(repo *velerov1api.ResticRepository) error
 
@@ -168,6 +174,14 @@ func (rm *repositoryManager) InitRepo(repo *velerov1api.ResticRepository) error 
 	defer rm.repoLocker.UnlockExclusive(repo.Name)
 
 	return rm.exec(InitCommand(repo.Spec.ResticIdentifier), repo.Spec.BackupStorageLocation)
+}
+
+func (rm *repositoryManager) ConnectToRepo(repo *velerov1api.ResticRepository) error {
+	// restic stats requires a non-exclusive lock
+	rm.repoLocker.Lock(repo.Name)
+	defer rm.repoLocker.Unlock(repo.Name)
+
+	return rm.exec(StatsCommand(repo.Spec.ResticIdentifier), repo.Spec.BackupStorageLocation)
 }
 
 func (rm *repositoryManager) CheckRepo(repo *velerov1api.ResticRepository) error {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

The first time Velero is performing an operation against a restic repository, it first checks to see if the repo exists, and if not, it initializes it.  Today, the way it checks if the repo exists is by running the `restic check` command with the right flags and auth, and sees if that succeeds. 

Turns out that this command can be quite slow the first time that it's run on a host/container that doesn't already have a local restic cache set up (e.g. in Cluster B's Velero pod in a Cluster A -> Cluster B migration).  An alternate command, `restic stats`, is much faster and also achieves the desired outcome of ensuring the restic repo exists and can be authenticated to.

I've tested this manually and can replicate the slow behavior with the current code, and can confirm that the updated code is much faster.