### PR TITLE
Update templates to use current command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Velero version (use `velero version`): 
+- Velero version (use `ark version`): 
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -14,7 +14,7 @@ about: Suggest an idea for this project
 
 **Environment:**
 
-- Velero version (use `velero version`):
+- Velero version (use `ark version`):
 - Kubernetes version (use `kubectl version`):
 - Kubernetes installer & version:
 - Cloud provider or hardware configuration:

--- a/pkg/cmd/cli/bug/bug.go
+++ b/pkg/cmd/cli/bug/bug.go
@@ -71,7 +71,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Velero version (use ` + "`velero version`" + `):{{.VeleroVersion}} {{.GitCommit}}
+- Velero version (use ` + "`ark version`" + `):{{.VeleroVersion}} {{.GitCommit}}
 - Kubernetes version (use ` + "`kubectl version`" + `): 
 {{- if .KubectlVersion}}
 ` + "```" + `


### PR DESCRIPTION
Currently, the executable binary in the wild is `ark`, so leave it in
our github issue templates

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>