### PR TITLE
update links to point to get-started.md

### DIFF
--- a/v0.10.0/namespace.md
+++ b/v0.10.0/namespace.md
@@ -71,4 +71,4 @@ ark client config set namespace=<NAMESPACE_VALUE>
 
 
 
-[0]: quickstart.md#download
+[0]: get-started.md#download

--- a/v0.10.0/support-matrix.md
+++ b/v0.10.0/support-matrix.md
@@ -46,7 +46,7 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [6]: https://docs.portworx.com/scheduler/kubernetes/ark.html
 [7]: https://github.com/StackPointCloud/ark-plugin-digitalocean
 [8]: https://github.com/heptio/ark-plugin-example/
-[9]: quickstart.md
+[9]: get-started.md
 [10]: https://kubernetes.slack.com/messages/ark-dr
 [11]: https://github.com/heptio/ark/issues
 [12]: https://github.com/aws/aws-sdk-go/aws

--- a/v0.10.0/upgrading-to-v0.10.md
+++ b/v0.10.0/upgrading-to-v0.10.md
@@ -86,4 +86,4 @@ rearrange any pre-v0.10 data as part of the upgrade. We've provided a script to 
 [2]: /api-types/volumesnapshotlocation.md
 [3]: storage-layout-reorg-v0.10.md
 [4]: locations.md
-[5]: quickstart.md#download
+[5]: get-started.md#download


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

`quickstart.md` was renamed to `get-started.md`.  This was fixed in `master` but not in the gh-pages `v0.10.0` dir.