### PR TITLE
Document build from release archive limitations

### DIFF
--- a/docs/build-from-scratch.md
+++ b/docs/build-from-scratch.md
@@ -31,6 +31,8 @@ For Go development, it is recommended to add the Go import path (`$HOME/go` in t
 ### Option 2) Release archive
 Download the archive named `Source code` from the [release page][22] and extract it in your Go import path as `src/github.com/heptio/velero`.
 
+Note that the Makefile targets assume building from a git repository. When building from an archive, you will be limited to the `go build` commands described below.
+
 ## Build
 
 You can build your Velero image locally on the machine where you run your cluster, or you can push it to a private registry. This section covers both workflows.


### PR DESCRIPTION
Due to the assumption of building from a git repository inherent in the
Makefile targets, update the documentation to limit source code archive
builds to the `go build` commands.

Note that it may be possible to update hack/build.sh to cope with
building outside a git repository, but there are a number of questions
to answer regarding how to populate the buildinfo info, and that is a
larger discussion than ensuring we can build the binary from the sources
in the source code archive.

Signed-off-by: Darren Hart <dvhart@vmware.com>