### PR TITLE
Fix restoring GCP regional disks

### DIFF
--- a/changelogs/unreleased/1200-nrb
+++ b/changelogs/unreleased/1200-nrb
@@ -1,0 +1,1 @@
+Set the zones for GCP regional disks on restore. This requires the `compute.zones.get` permission on the GCP serviceaccount in order to work correctly.

--- a/docs/gcp-config.md
+++ b/docs/gcp-config.md
@@ -67,6 +67,7 @@ To integrate Velero with GCP, create an Velero-specific [Service Account][15]:
         compute.snapshots.create
         compute.snapshots.useReadOnly
         compute.snapshots.delete
+        compute.zones.get
     )
 
     gcloud iam roles create velero.server \


### PR DESCRIPTION
To create a regional disk, the URLs for the zones in which the disk is
replicated must be provided to the GCP API.

Fixes #1183

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>