### PR TITLE
add deprecation notices to pkg/apis/ark/v1 types

### DIFF
--- a/pkg/apis/ark/v1/backup.go
+++ b/pkg/apis/ark/v1/backup.go
@@ -21,6 +21,10 @@ import (
 )
 
 // BackupSpec defines the specification for an Ark backup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupSpec struct {
 	// IncludedNamespaces is a slice of namespace names to include objects
 	// from. If empty, all namespaces are included.
@@ -67,6 +71,10 @@ type BackupSpec struct {
 }
 
 // BackupHooks contains custom behaviors that should be executed at different phases of the backup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupHooks struct {
 	// Resources are hooks that should be executed when backing up individual instances of a resource.
 	Resources []BackupResourceHookSpec `json:"resources"`
@@ -74,6 +82,10 @@ type BackupHooks struct {
 
 // BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
 // the rules defined for namespaces, resources, and label selector.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupResourceHookSpec struct {
 	// Name is the name of this hook.
 	Name string `json:"name"`
@@ -100,12 +112,20 @@ type BackupResourceHookSpec struct {
 }
 
 // BackupResourceHook defines a hook for a resource.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupResourceHook struct {
 	// Exec defines an exec hook.
 	Exec *ExecHook `json:"exec"`
 }
 
 // ExecHook is a hook that uses the pod exec API to execute a command in a container in a pod.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ExecHook struct {
 	// Container is the container in the pod where the command should be executed. If not specified,
 	// the pod's first container is used.
@@ -120,6 +140,10 @@ type ExecHook struct {
 }
 
 // HookErrorMode defines how Ark should treat an error from a hook.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type HookErrorMode string
 
 const (
@@ -133,6 +157,10 @@ const (
 
 // BackupPhase is a string representation of the lifecycle phase
 // of an Ark backup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupPhase string
 
 const (
@@ -160,6 +188,10 @@ const (
 )
 
 // BackupStatus captures the current status of an Ark backup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStatus struct {
 	// Version is the backup format version.
 	Version int `json:"version"`
@@ -208,6 +240,10 @@ type BackupStatus struct {
 // VolumeBackupInfo captures the required information about
 // a PersistentVolume at backup time to be able to restore
 // it later.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeBackupInfo struct {
 	// SnapshotID is the ID of the snapshot taken in the cloud
 	// provider API of this volume.
@@ -231,6 +267,10 @@ type VolumeBackupInfo struct {
 
 // Backup is an Ark resource that respresents the capture of Kubernetes
 // cluster state at a point in time (API objects and associated volume state).
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type Backup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -242,6 +282,10 @@ type Backup struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupList is a list of Backups.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/backup_storage_location.go
+++ b/pkg/apis/ark/v1/backup_storage_location.go
@@ -25,6 +25,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupStorageLocation is a location where Ark stores backup objects.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -36,6 +40,10 @@ type BackupStorageLocation struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupStorageLocationList is a list of BackupStorageLocations.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
@@ -44,11 +52,19 @@ type BackupStorageLocationList struct {
 
 // StorageType represents the type of storage that a backup location uses.
 // ObjectStorage must be non-nil, since it is currently the only supported StorageType.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type StorageType struct {
 	ObjectStorage *ObjectStorageLocation `json:"objectStorage,omitempty"`
 }
 
 // ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ObjectStorageLocation struct {
 	// Bucket is the bucket to use for object storage.
 	Bucket string `json:"bucket"`
@@ -58,6 +74,10 @@ type ObjectStorageLocation struct {
 }
 
 // BackupStorageLocationSpec defines the specification for an Ark BackupStorageLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocationSpec struct {
 	// Provider is the provider of the backup storage.
 	Provider string `json:"provider"`
@@ -69,6 +89,10 @@ type BackupStorageLocationSpec struct {
 }
 
 // BackupStorageLocationPhase is the lifecyle phase of an Ark BackupStorageLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocationPhase string
 
 const (
@@ -80,6 +104,10 @@ const (
 )
 
 // BackupStorageLocationAccessMode represents the permissions for a BackupStorageLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocationAccessMode string
 
 const (
@@ -91,6 +119,10 @@ const (
 )
 
 // BackupStorageLocationStatus describes the current status of an Ark BackupStorageLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type BackupStorageLocationStatus struct {
 	Phase              BackupStorageLocationPhase      `json:"phase,omitempty"`
 	AccessMode         BackupStorageLocationAccessMode `json:"accessMode,omitempty"`

--- a/pkg/apis/ark/v1/delete_backup_request.go
+++ b/pkg/apis/ark/v1/delete_backup_request.go
@@ -19,11 +19,19 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // DeleteBackupRequestSpec is the specification for which backups to delete.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DeleteBackupRequestSpec struct {
 	BackupName string `json:"backupName"`
 }
 
 // DeleteBackupRequestPhase represents the lifecycle phase of a DeleteBackupRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DeleteBackupRequestPhase string
 
 const (
@@ -36,6 +44,10 @@ const (
 )
 
 // DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DeleteBackupRequestStatus struct {
 	// Phase is the current state of the DeleteBackupRequest.
 	Phase DeleteBackupRequestPhase `json:"phase"`
@@ -47,6 +59,10 @@ type DeleteBackupRequestStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DeleteBackupRequest is a request to delete one or more backups.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DeleteBackupRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -58,6 +74,10 @@ type DeleteBackupRequest struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DeleteBackupRequestList is a list of DeleteBackupRequests.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DeleteBackupRequestList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/doc.go
+++ b/pkg/apis/ark/v1/doc.go
@@ -18,4 +18,7 @@ limitations under the License.
 
 // Package v1 is the v1 version of the API.
 // +groupName=ark.heptio.com
+//
+// Deprecated: Consumers should switch to github.com/heptio/velero/pkg/apis/velero/v1 instead.
+// This package will be removed in the v1.0 release.
 package v1

--- a/pkg/apis/ark/v1/download_request.go
+++ b/pkg/apis/ark/v1/download_request.go
@@ -19,12 +19,20 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // DownloadRequestSpec is the specification for a download request.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadRequestSpec struct {
 	// Target is what to download (e.g. logs for a backup).
 	Target DownloadTarget `json:"target"`
 }
 
 // DownloadTargetKind represents what type of file to download.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadTargetKind string
 
 const (
@@ -37,6 +45,10 @@ const (
 
 // DownloadTarget is the specification for what kind of file to download, and the name of the
 // resource with which it's associated.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadTarget struct {
 	// Kind is the type of file to download.
 	Kind DownloadTargetKind `json:"kind"`
@@ -45,6 +57,10 @@ type DownloadTarget struct {
 }
 
 // DownloadRequestPhase represents the lifecycle phase of a DownloadRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadRequestPhase string
 
 const (
@@ -57,6 +73,10 @@ const (
 )
 
 // DownloadRequestStatus is the current status of a DownloadRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadRequestStatus struct {
 	// Phase is the current state of the DownloadRequest.
 	Phase DownloadRequestPhase `json:"phase"`
@@ -71,6 +91,10 @@ type DownloadRequestStatus struct {
 
 // DownloadRequest is a request to download an artifact from backup object storage, such as a backup
 // log file.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -82,6 +106,10 @@ type DownloadRequest struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DownloadRequestList is a list of DownloadRequests.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type DownloadRequestList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/pod_volume_backup.go
+++ b/pkg/apis/ark/v1/pod_volume_backup.go
@@ -22,6 +22,10 @@ import (
 )
 
 // PodVolumeBackupSpec is the specification for a PodVolumeBackup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeBackupSpec struct {
 	// Node is the name of the node that the Pod is running on.
 	Node string `json:"node"`
@@ -46,6 +50,10 @@ type PodVolumeBackupSpec struct {
 }
 
 // PodVolumeBackupPhase represents the lifecycle phase of a PodVolumeBackup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeBackupPhase string
 
 const (
@@ -56,6 +64,10 @@ const (
 )
 
 // PodVolumeBackupStatus is the current status of a PodVolumeBackup.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeBackupStatus struct {
 	// Phase is the current state of the PodVolumeBackup.
 	Phase PodVolumeBackupPhase `json:"phase"`
@@ -73,6 +85,9 @@ type PodVolumeBackupStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeBackup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -84,6 +99,10 @@ type PodVolumeBackup struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodVolumeBackupList is a list of PodVolumeBackups.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeBackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/pod_volume_restore.go
+++ b/pkg/apis/ark/v1/pod_volume_restore.go
@@ -22,6 +22,10 @@ import (
 )
 
 // PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeRestoreSpec struct {
 	// Pod is a reference to the pod containing the volume to be restored.
 	Pod corev1api.ObjectReference `json:"pod"`
@@ -41,6 +45,10 @@ type PodVolumeRestoreSpec struct {
 }
 
 // PodVolumeRestorePhase represents the lifecycle phase of a PodVolumeRestore.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeRestorePhase string
 
 const (
@@ -51,6 +59,10 @@ const (
 )
 
 // PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeRestoreStatus struct {
 	// Phase is the current state of the PodVolumeRestore.
 	Phase PodVolumeRestorePhase `json:"phase"`
@@ -62,6 +74,10 @@ type PodVolumeRestoreStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeRestore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -73,6 +89,10 @@ type PodVolumeRestore struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodVolumeRestoreList is a list of PodVolumeRestores.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type PodVolumeRestoreList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/restic_repository.go
+++ b/pkg/apis/ark/v1/restic_repository.go
@@ -21,6 +21,10 @@ import (
 )
 
 // ResticRepositorySpec is the specification for a ResticRepository.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ResticRepositorySpec struct {
 	// VolumeNamespace is the namespace this restic repository contains
 	// pod volume backups for.
@@ -39,6 +43,10 @@ type ResticRepositorySpec struct {
 }
 
 // ResticRepositoryPhase represents the lifecycle phase of a ResticRepository.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ResticRepositoryPhase string
 
 const (
@@ -48,6 +56,10 @@ const (
 )
 
 // ResticRepositoryStatus is the current status of a ResticRepository.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ResticRepositoryStatus struct {
 	// Phase is the current state of the ResticRepository.
 	Phase ResticRepositoryPhase `json:"phase"`
@@ -62,6 +74,9 @@ type ResticRepositoryStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ResticRepository struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -73,6 +88,10 @@ type ResticRepository struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResticRepositoryList is a list of ResticRepositories.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ResticRepositoryList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/restore.go
+++ b/pkg/apis/ark/v1/restore.go
@@ -19,6 +19,10 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // RestoreSpec defines the specification for an Ark restore.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type RestoreSpec struct {
 	// BackupName is the unique name of the Ark backup to restore
 	// from.
@@ -68,6 +72,10 @@ type RestoreSpec struct {
 
 // RestorePhase is a string representation of the lifecycle phase
 // of an Ark restore
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type RestorePhase string
 
 const (
@@ -92,6 +100,10 @@ const (
 )
 
 // RestoreStatus captures the current status of an Ark restore
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type RestoreStatus struct {
 	// Phase is the current state of the Restore
 	Phase RestorePhase `json:"phase"`
@@ -115,6 +127,10 @@ type RestoreStatus struct {
 // RestoreResult is a collection of messages that were generated
 // during execution of a restore. This will typically store either
 // warning or error messages.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type RestoreResult struct {
 	// Ark is a slice of messages related to the operation of Ark
 	// itself (for example, messages related to connecting to the
@@ -135,6 +151,10 @@ type RestoreResult struct {
 
 // Restore is an Ark resource that represents the application of
 // resources from an Ark backup to a target Kubernetes cluster.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type Restore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -146,6 +166,10 @@ type Restore struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RestoreList is a list of Restores.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type RestoreList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/schedule.go
+++ b/pkg/apis/ark/v1/schedule.go
@@ -19,6 +19,10 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ScheduleSpec defines the specification for an Ark schedule
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ScheduleSpec struct {
 	// Template is the definition of the Backup to be run
 	// on the provided schedule
@@ -31,6 +35,10 @@ type ScheduleSpec struct {
 
 // SchedulePhase is a string representation of the lifecycle phase
 // of an Ark schedule
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type SchedulePhase string
 
 const (
@@ -48,6 +56,10 @@ const (
 )
 
 // ScheduleStatus captures the current state of an Ark schedule
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ScheduleStatus struct {
 	// Phase is the current phase of the Schedule
 	Phase SchedulePhase `json:"phase"`
@@ -66,6 +78,10 @@ type ScheduleStatus struct {
 
 // Schedule is an Ark resource that represents a pre-scheduled or
 // periodic Backup that should be run.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type Schedule struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -77,6 +93,10 @@ type Schedule struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ScheduleList is a list of Schedules.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ScheduleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/server_status_request.go
+++ b/pkg/apis/ark/v1/server_status_request.go
@@ -23,6 +23,10 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ServerStatusRequest is a request to access current status information about
 // the Ark server.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ServerStatusRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -32,10 +36,18 @@ type ServerStatusRequest struct {
 }
 
 // ServerStatusRequestSpec is the specification for a ServerStatusRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ServerStatusRequestSpec struct {
 }
 
 // ServerStatusRequestPhase represents the lifecycle phase of a ServerStatusRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ServerStatusRequestPhase string
 
 const (
@@ -46,6 +58,10 @@ const (
 )
 
 // ServerStatusRequestStatus is the current status of a ServerStatusRequest.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ServerStatusRequestStatus struct {
 	// Phase is the current lifecycle phase of the ServerStatusRequest.
 	Phase ServerStatusRequestPhase `json:"phase"`
@@ -61,6 +77,10 @@ type ServerStatusRequestStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServerStatusRequestList is a list of ServerStatusRequests.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type ServerStatusRequestList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/apis/ark/v1/volume_snapshot_location.go
+++ b/pkg/apis/ark/v1/volume_snapshot_location.go
@@ -22,6 +22,10 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VolumeSnapshotLocation is a location where Ark stores volume snapshots.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeSnapshotLocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -33,6 +37,10 @@ type VolumeSnapshotLocation struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // VolumeSnapshotLocationList is a list of VolumeSnapshotLocations.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeSnapshotLocationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
@@ -40,6 +48,10 @@ type VolumeSnapshotLocationList struct {
 }
 
 // VolumeSnapshotLocationSpec defines the specification for an Ark VolumeSnapshotLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeSnapshotLocationSpec struct {
 	// Provider is the provider of the volume storage.
 	Provider string `json:"provider"`
@@ -49,6 +61,10 @@ type VolumeSnapshotLocationSpec struct {
 }
 
 // VolumeSnapshotLocationPhase is the lifecyle phase of an Ark VolumeSnapshotLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeSnapshotLocationPhase string
 
 const (
@@ -60,6 +76,10 @@ const (
 )
 
 // VolumeSnapshotLocationStatus describes the current status of an Ark VolumeSnapshotLocation.
+//
+// Deprecated: Consumers should switch to the same type in
+// github.com/heptio/velero/pkg/apis/velero/v1 instead. This
+// type will be removed in the v1.0 release.
 type VolumeSnapshotLocationStatus struct {
 	Phase VolumeSnapshotLocationPhase `json:"phase,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

@nrb @carlisia I thought this was probably a good idea to add to all the types in `pkg/apis/ark/v1`.  Thoughts? Will add to the rest pending any feedback.