### PR TITLE
Fix documentation link to reflect project name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ redirect_to:
 - LATEST
 ---
 
-# ark - Docs Branch
+# velero - Docs Branch
 
-This special branch (`gh-pages`) is used to generate the [public documentation site](https://heptio.github.io/ark)
-for ark. This site is hosted using [Github Pages](https://help.github.com/articles/what-is-github-pages/).
+This special branch (`gh-pages`) is used to generate the [public documentation site](https://heptio.github.io/velero)
+for velero. This site is hosted using [Github Pages](https://help.github.com/articles/what-is-github-pages/).
 
 The content files in this branch were generated with a tool that Heptio builds and maintains. This means that if you change docs content in this branch to fix something on the docs site, make sure to change the equivalent content in the docs directory on the master branch.


### PR DESCRIPTION
This PR updates the documentation link to point to velero as opposed to ark. I also updated existing ark references to velero.