### PR TITLE
Use local git checkout to build docs

### DIFF
--- a/gen_version.sh
+++ b/gen_version.sh
@@ -6,11 +6,13 @@ fi
 
 VERSION=$1
 
+# If the version is master, we'll re-use the dir.
 if [[ $VERSION != "master" ]]; then
-  GH_BASE_URL=https://github.com/heptio/velero/tags/$VERSION
-else
-  GH_BASE_URL=https://github.com/heptio/velero/branches/master
+  mkdir $VERSION
 fi
 
-svn export $GH_BASE_URL/docs/ $VERSION/ || (echo "Failed to copy docs for version $VERSION" && exit -1)
-svn export --force $GH_BASE_URL/README.md $VERSION/README.md || (echo "Failed to copy README for version $VERSION" && exit -1)
+# Get the documentation out of the local clone of master and place them into the $VERSION's directory
+# --strip-components 1 makes sure we don't end up with docs in $VERSIONS/docs
+git archive master docs/ | tar -x --strip-components 1 -C $VERSION
+# The README is used as the index
+git show master:README.md > $VERSION/README.md


### PR DESCRIPTION
This change enables us to build documentation prior to actually cutting
a tag.

Testing locally appeared to work.

```
% git checkout gh-pages
% doc-site-gen add v0.11.0
Updating versions in _config.yml...
Done!
Copying docs for version v0.11.0 ...
Done!
Fixing links on homepage...
Done!
```

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>