### PR TITLE
defer closing the ReadCloser in ObjectStoreGRPCServer.GetObject

### DIFF
--- a/changelogs/unreleased/1236-DheerajSShetty
+++ b/changelogs/unreleased/1236-DheerajSShetty
@@ -1,0 +1,1 @@
+Need to defer closing the the ReadCloser in ObjectStoreGRPCServer.GetObject

--- a/pkg/plugin/object_store.go
+++ b/pkg/plugin/object_store.go
@@ -284,6 +284,7 @@ func (s *ObjectStoreGRPCServer) GetObject(req *proto.GetObjectRequest, stream pr
 	if err != nil {
 		return err
 	}
+	defer rdr.Close()
 
 	chunk := make([]byte, byteChunkSize)
 	for {


### PR DESCRIPTION
Signed-off-by: DheerajSShetty <dheerajs@vmware.com>

Fixes #1093