### PR TITLE
v0.10.2 and v0.11.0 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,11 @@
 ## Development release:
+  * [Unreleased Changes][0]
 
-  * [Unreleased Changes][9]
-
-### Bug Fixes / Other Changes
-  * add multizone/regional support to gcp (#765, @wwitzel3)
-  * Delete spec.priority in pod restore action (#879, @mwieczorek)
-  * Added brew reference (#1051, @omerlh)
-  * Update to go 1.11 (#1069, @gliptak)
-  * Initialize empty schedule metrics on server init (#1054, @cbeneke)
-  * Update CHANGELOGs (#1063, @wwitzel3)
-  * Remove default token from all service accounts (#1048, @ncdc)
-  * Allow to use AWS Signature v1 for creating signed AWS urls (#811, @bashofmann)
-  
 ## Current release:
-  * [CHANGELOG-0.10.md][8]
+  * [CHANGELOG-0.11.md][9]
 
 ## Older releases:
+  * [CHANGELOG-0.10.md][8]
   * [CHANGELOG-0.9.md][7]
   * [CHANGELOG-0.8.md][6]
   * [CHANGELOG-0.7.md][5]
@@ -24,12 +14,14 @@
   * [CHANGELOG-0.4.md][2]
   * [CHANGELOG-0.3.md][1]
 
-[9]: https://github.com/heptio/ark/blob/master/changelogs/unreleased
-[8]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.10.md
-[7]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.9.md
-[6]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.8.md
-[5]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.7.md
-[4]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.6.md
-[3]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.5.md
-[2]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.4.md
-[1]: https://github.com/heptio/ark/blob/master/changelogs/CHANGELOG-0.3.md
+
+[9]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.11.md
+[8]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.10.md
+[7]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.9.md
+[6]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.8.md
+[5]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.7.md
+[4]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.6.md
+[3]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.5.md
+[2]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.4.md
+[1]: https://github.com/heptio/velero/blob/master/changelogs/CHANGELOG-0.3.md
+[0]: https://github.com/heptio/velero/blob/master/changelogs/unreleased

--- a/changelogs/CHANGELOG-0.10.md
+++ b/changelogs/CHANGELOG-0.10.md
@@ -1,5 +1,17 @@
+  - [v0.10.2](#v0102)
   - [v0.10.1](#v0101)
   - [v0.10.0](#v0100)
+
+## v0.10.2
+#### 2019-02-28
+
+### Download
+- https://github.com/heptio/ark/releases/tag/v0.10.2
+
+### Changes
+  * upgrade restic to v0.9.4 & replace --hostname flag with --host (#1156, @skriss)
+  * use 'restic stats' instead of 'restic check' to determine if repo exists (#1171, @skriss)
+  * Fix concurrency bug in code ensuring restic repository exists (#1235, @skriss)
 
 ## v0.10.1
 #### 2019-01-10

--- a/changelogs/CHANGELOG-0.11.md
+++ b/changelogs/CHANGELOG-0.11.md
@@ -1,0 +1,25 @@
+  - [v0.11.0](#v0110)
+
+## v0.11.0
+#### 2019-02-28
+
+### Download
+- https://github.com/heptio/velero/releases/tag/v0.11.0
+
+### Highlights
+* Heptio Ark is now Velero! This release is the first one to use the new name. For details on the changes and how to migrate to v0.11, see the [migration instructions][1]. **Please follow the instructions to ensure a successful upgrade to v0.11.**
+* Restic has been upgraded to v0.9.4, which brings significantly faster restores thanks to a new multi-threaded restorer.
+* Velero now waits for terminating namespaces and persistent volumes to delete before attempting to restore them, rather than trying and failing to restore them while they're being deleted.
+
+### All Changes
+* Fix concurrency bug in code ensuring restic repository exists (#1235, @skriss)
+* Wait for PVs and namespaces to delete before attempting to restore them. (#826, @nrb)
+* Set the zones for GCP regional disks on restore. This requires the `compute.zones.get` permission on the GCP serviceaccount in order to work correctly. (#1200, @nrb)
+* Renamed Heptio Ark to Velero. Changed internal imports, environment variables, and binary name. (#1184, @nrb)
+* use 'restic stats' instead of 'restic check' to determine if repo exists (#1171, @skriss)
+* upgrade restic to v0.9.4 & replace --hostname flag with --host (#1156, @skriss)
+* Clarify restore log when object unchanged (#1153, @daved)
+* Add backup-version file in backup tarball. (#1117, @wwitzel3)
+* add ServerStatusRequest CRD and show server version in `ark version` output (#1116, @skriss)
+
+[1]: https://heptio.github.io/velero/v0.11.0/migrating-to-velero

--- a/changelogs/unreleased/1116-skriss
+++ b/changelogs/unreleased/1116-skriss
@@ -1,1 +1,0 @@
-add ServerStatusRequest CRD and show server version in `ark version` output

--- a/changelogs/unreleased/1117-wwitzel3
+++ b/changelogs/unreleased/1117-wwitzel3
@@ -1,1 +1,0 @@
-Add backup-version file in backup tarball.

--- a/changelogs/unreleased/1153-daved
+++ b/changelogs/unreleased/1153-daved
@@ -1,1 +1,0 @@
-Clarify restore log when object unchanged

--- a/changelogs/unreleased/1156-skriss
+++ b/changelogs/unreleased/1156-skriss
@@ -1,1 +1,0 @@
-upgrade restic to v0.9.4 & replace --hostname flag with --host

--- a/changelogs/unreleased/1171-skriss
+++ b/changelogs/unreleased/1171-skriss
@@ -1,1 +1,0 @@
-use 'restic stats' instead of 'restic check' to determine if repo exists

--- a/changelogs/unreleased/1184-nrb
+++ b/changelogs/unreleased/1184-nrb
@@ -1,1 +1,0 @@
-Renamed Heptio Ark to Velero. Changed internal imports, environment variables, and binary name.

--- a/changelogs/unreleased/1200-nrb
+++ b/changelogs/unreleased/1200-nrb
@@ -1,1 +1,0 @@
-Set the zones for GCP regional disks on restore. This requires the `compute.zones.get` permission on the GCP serviceaccount in order to work correctly.

--- a/changelogs/unreleased/1235-skriss
+++ b/changelogs/unreleased/1235-skriss
@@ -1,1 +1,0 @@
-Fix concurrency bug in code ensuring restic repository exists

--- a/changelogs/unreleased/826-nrb
+++ b/changelogs/unreleased/826-nrb
@@ -1,1 +1,0 @@
-Wait for PVs and namespaces to delete before attempting to restore them.


### PR DESCRIPTION
Let's not merge this until tomorrow AM, but pls let me know if you have any feedback on the text.

Note the v0.10.2 one is here since I merged it into the `release-0.10` branch but not `master`, and it should be in both.

@carlisia @nrb 