### PR TITLE
when restoring a PV, don't remove its spec.storageClassName

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1126,7 +1126,6 @@ func (r *pvRestorer) executePVAction(obj *unstructured.Unstructured) (*unstructu
 	}
 
 	delete(spec, "claimRef")
-	delete(spec, "storageClassName")
 
 	if boolptr.IsSetToFalse(r.snapshotVolumes) {
 		// The backup had snapshots disabled, so we can return early

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1346,18 +1346,25 @@ func TestExecutePVAction_NoSnapshotRestores(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:        "ensure spec.claimRef, spec.storageClassName are deleted",
-			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "storageClassName", "someOtherField").Unstructured,
+			name:        "ensure spec.claimRef is deleted",
+			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "someOtherField").Unstructured,
 			restore:     velerotest.NewDefaultTestRestore().WithRestorePVs(false).Restore,
 			backup:      velerotest.NewTestBackup().WithName("backup1").WithPhase(api.BackupPhaseInProgress).Backup,
 			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("someOtherField").Unstructured,
+		},
+		{
+			name:        "ensure spec.storageClassName is retained",
+			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("storageClassName", "someOtherField").Unstructured,
+			restore:     velerotest.NewDefaultTestRestore().WithRestorePVs(false).Restore,
+			backup:      velerotest.NewTestBackup().WithName("backup1").WithPhase(api.BackupPhaseInProgress).Backup,
+			expectedRes: NewTestUnstructured().WithAnnotations("a", "b").WithName("pv-1").WithSpec("storageClassName", "someOtherField").Unstructured,
 		},
 		{
 			name:        "if backup.spec.snapshotVolumes is false, ignore restore.spec.restorePVs and return early",
 			obj:         NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("claimRef", "storageClassName", "someOtherField").Unstructured,
 			restore:     velerotest.NewDefaultTestRestore().WithRestorePVs(true).Restore,
 			backup:      velerotest.NewTestBackup().WithName("backup1").WithPhase(api.BackupPhaseInProgress).WithSnapshotVolumes(false).Backup,
-			expectedRes: NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("someOtherField").Unstructured,
+			expectedRes: NewTestUnstructured().WithName("pv-1").WithAnnotations("a", "b").WithSpec("storageClassName", "someOtherField").Unstructured,
 		},
 		{
 			name:    "restore.spec.restorePVs=false, return early",


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1097 

I tested this on a couple public clouds and it worked fine.