### PR TITLE
Improve `describe` output

### DIFF
--- a/changelogs/unreleased/1248-DheerajSShetty
+++ b/changelogs/unreleased/1248-DheerajSShetty
@@ -1,0 +1,6 @@
+Improve `describe` output
+   * Move Phase to right under Metadata(name/namespace/label/annotations)
+   * Move Validation errors: section right after Phase: section and only
+     show it if the item has a phase of FailedValidation
+   * For restores move Warnings and Errors under Validation errors. Leave
+     their display as is.

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -49,6 +49,15 @@ func DescribeBackup(
 		}
 		d.Printf("Phase:\t%s\n", phase)
 
+		status := backup.Status
+		if len(status.ValidationErrors) > 0 {
+			d.Println()
+			d.Printf("Validation errors:")
+			for _, ve := range status.ValidationErrors {
+				d.Printf("\t%s\n", ve)
+			}
+		}
+
 		d.Println()
 		DescribeBackupSpec(d, backup.Spec)
 
@@ -201,16 +210,6 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Printf("Expiration:\t%s\n", status.Expiration.Time)
 	d.Println()
 
-	d.Printf("Validation errors:")
-	if len(status.ValidationErrors) == 0 {
-		d.Printf("\t<none>\n")
-	} else {
-		for _, ve := range status.ValidationErrors {
-			d.Printf("\t%s\n", ve)
-		}
-	}
-
-	d.Println()
 	if len(status.VolumeBackups) > 0 {
 		// pre-v0.10 backup
 		d.Printf("Persistent Volumes:\n")

--- a/pkg/cmd/util/output/schedule_describer.go
+++ b/pkg/cmd/util/output/schedule_describer.go
@@ -27,6 +27,22 @@ func DescribeSchedule(schedule *v1.Schedule) string {
 		d.DescribeMetadata(schedule.ObjectMeta)
 
 		d.Println()
+		phase := schedule.Status.Phase
+		if phase == "" {
+			phase = v1.SchedulePhaseNew
+		}
+		d.Printf("Phase:\t%s\n", phase)
+
+		status := schedule.Status
+		if len(status.ValidationErrors) > 0 {
+			d.Println()
+			d.Printf("Validation errors:")
+			for _, ve := range status.ValidationErrors {
+				d.Printf("\t%s\n", ve)
+			}
+		}
+
+		d.Println()
 		DescribeScheduleSpec(d, schedule.Spec)
 
 		d.Println()
@@ -45,21 +61,6 @@ func DescribeScheduleSpec(d *Describer, spec v1.ScheduleSpec) {
 }
 
 func DescribeScheduleStatus(d *Describer, status v1.ScheduleStatus) {
-	phase := status.Phase
-	if phase == "" {
-		phase = v1.SchedulePhaseNew
-	}
-
-	d.Printf("Validation errors:")
-	if len(status.ValidationErrors) == 0 {
-		d.Printf("\t<none>\n")
-	} else {
-		for _, ve := range status.ValidationErrors {
-			d.Printf("\t%s\n", ve)
-		}
-	}
-
-	d.Println()
 	lastBackup := "<never>"
 	if !status.LastBackup.Time.IsZero() {
 		lastBackup = fmt.Sprintf("%v", status.LastBackup.Time)


### PR DESCRIPTION
Improve `describe` output
   * Move Phase to right under Metadata(name/namespace/label/annotations)
   * Move Validation errors: section right after Phase: section and only
     show it if the item has a phase of FailedValidation
   * For restores move Warnings and Errors under Validation errors. Do not
      show Warnings or Errors if there are none.

Signed-off-by: DheerajSShetty <dheerajs@vmware.com>

Fixes #987