### PR TITLE
remove restore code that waits for a PV to become Available

### DIFF
--- a/changelogs/unreleased/1254-skriss
+++ b/changelogs/unreleased/1254-skriss
@@ -1,0 +1,1 @@
+remove restore code that waits for a PV to become Available


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

One more cleanup PR for `pkg/restore`.  This code ran during a restore, and waited (up to a minute) for all restored PVs to have a phase of `Available` before moving on to restoring other resources (e.g. PVCs).  The intent was to streamline creation of PVs, but we've looked at this previously and determined it's not necessary. Kubernetes will do the necessary retries, it immediately moves new PVs to `Available` phase if they're not already claimed, and PVCs will claim `Pending` PVs just fine anyway.

I did some testing on this, but if someone has time, would be great to get a second pair of eyes on it.