### PR TITLE
Refactor out plugin interfaces

### DIFF
--- a/pkg/plugin/backup/backup_item_action.go
+++ b/pkg/plugin/backup/backup_item_action.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"encoding/json"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	api "github.com/heptio/velero/pkg/apis/velero/v1"
+	velerobackup "github.com/heptio/velero/pkg/backup"
+	"github.com/heptio/velero/pkg/plugin/framework"
+	proto "github.com/heptio/velero/pkg/plugin/generated"
+)
+
+// ItemActionPlugin is an implementation of go-plugin's Plugin
+// interface with support for gRPC for the backup/ItemAction
+// interface.
+type ItemActionPlugin struct {
+	plugin.NetRPCUnsupportedPlugin
+	*framework.PluginBase
+}
+
+// NewBackupItemActionPlugin constructs a ItemActionPlugin for backups.
+func NewBackupItemActionPlugin(options ...framework.PluginOption) *ItemActionPlugin {
+	return &ItemActionPlugin{
+		PluginBase: framework.NewPluginBase(options...),
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// client code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCClient returns a ItemActionPlugin gRPC client for backup.
+func (p *ItemActionPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return framework.NewClientDispenser(p.ClientLogger, c, newBackupItemActionGRPCClient), nil
+}
+
+// ItemActionGRPCClient implements the backup/ItemAction interface and uses a
+// gRPC client to make calls to the plugin server.
+type ItemActionGRPCClient struct {
+	*framework.ClientBase
+	grpcClient proto.BackupItemActionClient
+}
+
+func newBackupItemActionGRPCClient(base *framework.ClientBase, clientConn *grpc.ClientConn) interface{} {
+	return &ItemActionGRPCClient{
+		ClientBase: base,
+		grpcClient: proto.NewBackupItemActionClient(clientConn),
+	}
+}
+
+func (c *ItemActionGRPCClient) AppliesTo() (velerobackup.ResourceSelector, error) {
+	res, err := c.grpcClient.AppliesTo(context.Background(), &proto.AppliesToRequest{Plugin: c.Plugin})
+	if err != nil {
+		return velerobackup.ResourceSelector{}, err
+	}
+
+	return velerobackup.ResourceSelector{
+		IncludedNamespaces: res.IncludedNamespaces,
+		ExcludedNamespaces: res.ExcludedNamespaces,
+		IncludedResources:  res.IncludedResources,
+		ExcludedResources:  res.ExcludedResources,
+		LabelSelector:      res.Selector,
+	}, nil
+}
+
+func (c *ItemActionGRPCClient) Execute(item runtime.Unstructured, backup *api.Backup) (runtime.Unstructured, []velerobackup.ResourceIdentifier, error) {
+	itemJSON, err := json.Marshal(item.UnstructuredContent())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	backupJSON, err := json.Marshal(backup)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req := &proto.ExecuteRequest{
+		Plugin: c.Plugin,
+		Item:   itemJSON,
+		Backup: backupJSON,
+	}
+
+	res, err := c.grpcClient.Execute(context.Background(), req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var updatedItem unstructured.Unstructured
+	if err := json.Unmarshal(res.Item, &updatedItem); err != nil {
+		return nil, nil, err
+	}
+
+	var additionalItems []velerobackup.ResourceIdentifier
+
+	for _, itm := range res.AdditionalItems {
+		newItem := velerobackup.ResourceIdentifier{
+			GroupResource: schema.GroupResource{
+				Group:    itm.Group,
+				Resource: itm.Resource,
+			},
+			Namespace: itm.Namespace,
+			Name:      itm.Name,
+		}
+
+		additionalItems = append(additionalItems, newItem)
+	}
+
+	return &updatedItem, additionalItems, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// server code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCServer registers a BackupItemAction gRPC server.
+func (p *ItemActionPlugin) GRPCServer(s *grpc.Server) error {
+	proto.RegisterBackupItemActionServer(s, &ItemActionGRPCServer{mux: p.ServerMux})
+	return nil
+}
+
+// ItemActionGRPCServer implements the proto-generated ItemActionGRPCServer interface, and accepts
+// gRPC calls and forwards them to an implementation of the pluggable interface.
+type ItemActionGRPCServer struct {
+	mux *framework.ServerMux
+}
+
+func (s *ItemActionGRPCServer) getImpl(name string) (velerobackup.ItemAction, error) {
+	impl, err := s.mux.GetHandler(name)
+	if err != nil {
+		return nil, err
+	}
+
+	itemAction, ok := impl.(velerobackup.ItemAction)
+	if !ok {
+		return nil, errors.Errorf("%T is not a backup item action", impl)
+	}
+
+	return itemAction, nil
+}
+
+func (s *ItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.AppliesToRequest) (*proto.AppliesToResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceSelector, err := impl.AppliesTo()
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.AppliesToResponse{
+		IncludedNamespaces: resourceSelector.IncludedNamespaces,
+		ExcludedNamespaces: resourceSelector.ExcludedNamespaces,
+		IncludedResources:  resourceSelector.IncludedResources,
+		ExcludedResources:  resourceSelector.ExcludedResources,
+		Selector:           resourceSelector.LabelSelector,
+	}, nil
+}
+
+func (s *ItemActionGRPCServer) Execute(ctx context.Context, req *proto.ExecuteRequest) (*proto.ExecuteResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	var item unstructured.Unstructured
+	var backup api.Backup
+
+	if err := json.Unmarshal(req.Item, &item); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(req.Backup, &backup); err != nil {
+		return nil, err
+	}
+
+	updatedItem, additionalItems, err := impl.Execute(&item, &backup)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the plugin implementation returned a nil updatedItem (meaning no modifications), reset updatedItem to the
+	// original item.
+	var updatedItemJSON []byte
+	if updatedItem == nil {
+		updatedItemJSON = req.Item
+	} else {
+		updatedItemJSON, err = json.Marshal(updatedItem.UnstructuredContent())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	res := &proto.ExecuteResponse{
+		Item: updatedItemJSON,
+	}
+
+	for _, item := range additionalItems {
+		res.AdditionalItems = append(res.AdditionalItems, backupResourceIdentifierToProto(item))
+	}
+
+	return res, nil
+}
+
+func backupResourceIdentifierToProto(id velerobackup.ResourceIdentifier) *proto.ResourceIdentifier {
+	return &proto.ResourceIdentifier{
+		Group:     id.Group,
+		Resource:  id.Resource,
+		Namespace: id.Namespace,
+		Name:      id.Name,
+	}
+}

--- a/pkg/plugin/backup/backup_item_action_test.go
+++ b/pkg/plugin/backup/backup_item_action_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/backup"
+	"github.com/heptio/velero/pkg/backup/mocks"
+	"github.com/heptio/velero/pkg/plugin/framework"
+	proto "github.com/heptio/velero/pkg/plugin/generated"
+	velerotest "github.com/heptio/velero/pkg/util/test"
+)
+
+func TestBackupItemActionGRPCServerExecute(t *testing.T) {
+	invalidItem := []byte("this is gibberish json")
+	validItem := []byte(`
+	{
+		"apiVersion": "v1",
+		"kind": "ConfigMap",
+		"metadata": {
+			"namespace": "myns",
+			"name": "myconfigmap"
+		},
+		"data": {
+			"key": "value"
+		}
+	}`)
+	var validItemObject unstructured.Unstructured
+	err := json.Unmarshal(validItem, &validItemObject)
+	require.NoError(t, err)
+
+	updatedItem := []byte(`
+		{
+			"apiVersion": "v1",
+			"kind": "ConfigMap",
+			"metadata": {
+				"namespace": "myns",
+				"name": "myconfigmap"
+			},
+			"data": {
+				"key": "changed!"
+			}
+		}`)
+	var updatedItemObject unstructured.Unstructured
+	err = json.Unmarshal(updatedItem, &updatedItemObject)
+	require.NoError(t, err)
+
+	invalidBackup := []byte("this is gibberish json")
+	validBackup := []byte(`
+	{
+		"apiVersion": "velero.io/v1",
+		"kind": "Backup",
+		"metadata": {
+			"namespace": "myns",
+			"name": "mybackup"
+		},
+		"spec": {
+			"includedNamespaces": ["*"],
+			"includedResources": ["*"],
+			"ttl": "60m"
+		}
+	}`)
+	var validBackupObject v1.Backup
+	err = json.Unmarshal(validBackup, &validBackupObject)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                string
+		backup              []byte
+		item                []byte
+		implUpdatedItem     runtime.Unstructured
+		implAdditionalItems []backup.ResourceIdentifier
+		implError           error
+		expectError         bool
+		skipMock            bool
+	}{
+		{
+			name:        "error unmarshaling item",
+			item:        invalidItem,
+			backup:      validBackup,
+			expectError: true,
+			skipMock:    true,
+		},
+		{
+			name:        "error unmarshaling backup",
+			item:        validItem,
+			backup:      invalidBackup,
+			expectError: true,
+			skipMock:    true,
+		},
+		{
+			name:        "error running impl",
+			item:        validItem,
+			backup:      validBackup,
+			implError:   errors.New("impl error"),
+			expectError: true,
+		},
+		{
+			name:   "nil updatedItem / no additionalItems",
+			item:   validItem,
+			backup: validBackup,
+		},
+		{
+			name:            "same updatedItem / some additionalItems",
+			item:            validItem,
+			backup:          validBackup,
+			implUpdatedItem: &validItemObject,
+			implAdditionalItems: []backup.ResourceIdentifier{
+				{
+					GroupResource: schema.GroupResource{Group: "v1", Resource: "pods"},
+					Namespace:     "myns",
+					Name:          "mypod",
+				},
+			},
+		},
+		{
+			name:            "different updatedItem",
+			item:            validItem,
+			backup:          validBackup,
+			implUpdatedItem: &updatedItemObject,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			itemAction := &mocks.ItemAction{}
+			defer itemAction.AssertExpectations(t)
+
+			if !test.skipMock {
+				itemAction.On("Execute", &validItemObject, &validBackupObject).Return(test.implUpdatedItem, test.implAdditionalItems, test.implError)
+			}
+
+			s := ItemActionGRPCServer{mux: &framework.ServerMux{
+				ServerLog: velerotest.NewLogger(),
+				Handlers: map[string]interface{}{
+					"xyz": itemAction,
+				},
+			}}
+
+			req := &proto.ExecuteRequest{
+				Plugin: "xyz",
+				Item:   test.item,
+				Backup: test.backup,
+			}
+
+			resp, err := s.Execute(context.Background(), req)
+
+			// Verify error
+			assert.Equal(t, test.expectError, err != nil)
+			if err != nil {
+				return
+			}
+			require.NotNil(t, resp)
+
+			// Verify updated item
+			updatedItem := test.implUpdatedItem
+			if updatedItem == nil {
+				// If the impl returned nil for its updatedItem, we should expect the plugin to return the original item
+				updatedItem = &validItemObject
+			}
+
+			var respItem unstructured.Unstructured
+			err = json.Unmarshal(resp.Item, &respItem)
+			require.NoError(t, err)
+
+			assert.Equal(t, updatedItem, &respItem)
+
+			// Verify additional items
+			var expectedAdditionalItems []*proto.ResourceIdentifier
+			for _, item := range test.implAdditionalItems {
+				expectedAdditionalItems = append(expectedAdditionalItems, backupResourceIdentifierToProto(item))
+			}
+			assert.Equal(t, expectedAdditionalItems, resp.AdditionalItems)
+		})
+	}
+}

--- a/pkg/plugin/framework/client_dispenser.go
+++ b/pkg/plugin/framework/client_dispenser.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// clientBase implements client and contains shared fields common to all clients.
+type ClientBase struct {
+	Plugin string
+	logger logrus.FieldLogger
+}
+
+type ClientDispenser interface {
+	clientFor(name string) interface{}
+}
+
+// clientDispenser supports the initialization and retrieval of multiple implementations for a single plugin kind, such as
+// "aws" and "azure" implementations of the object store plugin.
+type clientDispenser struct {
+	// Logger is the log the plugin should use.
+	Logger logrus.FieldLogger
+	// ClientConn is shared among all implementations for this client.
+	ClientConn *grpc.ClientConn
+	// InitFunc returns a client that implements a plugin interface, such as cloudprovider.ObjectStore.
+	InitFunc clientInitFunc
+	// Clients keeps track of all the initialized implementations.
+	Clients map[string]interface{}
+}
+
+type clientInitFunc func(base *ClientBase, clientConn *grpc.ClientConn) interface{}
+
+// newClientDispenser creates a new clientDispenser.
+func NewClientDispenser(logger logrus.FieldLogger, clientConn *grpc.ClientConn, initFunc clientInitFunc) *clientDispenser {
+	return &clientDispenser{
+		ClientConn: clientConn,
+		Logger:     logger,
+		InitFunc:   initFunc,
+		Clients:    make(map[string]interface{}),
+	}
+}
+
+// clientFor returns a gRPC client stub for the implementation of a plugin named name. If the client stub does not
+// currently exist, clientFor creates it.
+func (cd *clientDispenser) clientFor(name string) interface{} {
+	if client, found := cd.Clients[name]; found {
+		return client
+	}
+
+	base := &ClientBase{
+		Plugin: name,
+		logger: cd.Logger,
+	}
+	// Initialize the plugin (e.g. newBackupItemActionGRPCClient())
+	client := cd.InitFunc(base, cd.ClientConn)
+	cd.Clients[name] = client
+
+	return client
+}

--- a/pkg/plugin/framework/client_dispenser_test.go
+++ b/pkg/plugin/framework/client_dispenser_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/heptio/velero/pkg/util/test"
+)
+
+type fakeClient struct {
+	base       *ClientBase
+	clientConn *grpc.ClientConn
+}
+
+func TestNewClientDispenser(t *testing.T) {
+	logger := test.NewLogger()
+
+	clientConn := new(grpc.ClientConn)
+
+	c := 3
+	initFunc := func(base *ClientBase, clientConn *grpc.ClientConn) interface{} {
+		return c
+	}
+
+	cd := NewClientDispenser(logger, clientConn, initFunc)
+	assert.Equal(t, clientConn, cd.ClientConn)
+	assert.NotNil(t, cd.Clients)
+	assert.Empty(t, cd.Clients)
+}
+
+func TestClientFor(t *testing.T) {
+	logger := test.NewLogger()
+	clientConn := new(grpc.ClientConn)
+
+	c := new(fakeClient)
+	count := 0
+	initFunc := func(base *ClientBase, clientConn *grpc.ClientConn) interface{} {
+		c.base = base
+		c.clientConn = clientConn
+		count++
+		return c
+	}
+
+	cd := NewClientDispenser(logger, clientConn, initFunc)
+
+	actual := cd.clientFor("pod")
+	require.IsType(t, &fakeClient{}, actual)
+	typed := actual.(*fakeClient)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, &typed, &c)
+	expectedBase := &ClientBase{
+		Plugin: "pod",
+		logger: logger,
+	}
+	assert.Equal(t, expectedBase, typed.base)
+	assert.Equal(t, clientConn, typed.clientConn)
+
+	// Make sure we reuse a previous client
+	actual = cd.clientFor("pod")
+	require.IsType(t, &fakeClient{}, actual)
+	typed = actual.(*fakeClient)
+	assert.Equal(t, 1, count)
+}

--- a/pkg/plugin/framework/plugin_base.go
+++ b/pkg/plugin/framework/plugin_base.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "github.com/sirupsen/logrus"
+
+type PluginBase struct {
+	ClientLogger logrus.FieldLogger
+	*ServerMux
+}
+
+func NewPluginBase(options ...PluginOption) *PluginBase {
+	base := new(PluginBase)
+	for _, option := range options {
+		option(base)
+	}
+	return base
+}
+
+type PluginOption func(base *PluginBase)
+
+func clientLogger(logger logrus.FieldLogger) PluginOption {
+	return func(base *PluginBase) {
+		base.ClientLogger = logger
+	}
+}
+
+func serverLogger(logger logrus.FieldLogger) PluginOption {
+	return func(base *PluginBase) {
+		base.ServerMux = newServerMux(logger)
+	}
+}

--- a/pkg/plugin/framework/plugin_base_test.go
+++ b/pkg/plugin/framework/plugin_base_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/heptio/velero/pkg/util/test"
+)
+
+func TestClientLogger(t *testing.T) {
+	base := &PluginBase{}
+	logger := test.NewLogger()
+	f := clientLogger(logger)
+	f(base)
+	assert.Equal(t, logger, base.ClientLogger)
+}
+
+func TestServerLogger(t *testing.T) {
+	base := &PluginBase{}
+	logger := test.NewLogger()
+	f := serverLogger(logger)
+	f(base)
+	assert.Equal(t, newServerMux(logger), base.ServerMux)
+}

--- a/pkg/plugin/framework/plugin_kinds.go
+++ b/pkg/plugin/framework/plugin_kinds.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// PluginKind is a type alias for a string that describes
+// the kind of a Velero-supported plugin.
+type PluginKind string
+
+// String returns the string for k.
+func (k PluginKind) String() string {
+	return string(k)
+}
+
+const (
+	// PluginKindObjectStore represents an object store plugin.
+	PluginKindObjectStore PluginKind = "ObjectStore"
+
+	// PluginKindBlockStore represents a block store plugin.
+	PluginKindBlockStore PluginKind = "BlockStore"
+
+	// PluginKindBackupItemAction represents a backup item action plugin.
+	PluginKindBackupItemAction PluginKind = "BackupItemAction"
+
+	// PluginKindRestoreItemAction represents a restore item action plugin.
+	PluginKindRestoreItemAction PluginKind = "RestoreItemAction"
+
+	// PluginKindPluginLister represents a plugin lister plugin.
+	PluginKindPluginLister PluginKind = "PluginLister"
+)
+
+// allPluginKinds contains all the valid plugin kinds that Velero supports, excluding PluginLister because that is not a
+// kind that a developer would ever need to implement (it's handled by Velero and the Velero plugin library code).
+var allPluginKinds = sets.NewString(
+	PluginKindObjectStore.String(),
+	PluginKindBlockStore.String(),
+	PluginKindBackupItemAction.String(),
+	PluginKindRestoreItemAction.String(),
+)

--- a/pkg/plugin/framework/server_mux.go
+++ b/pkg/plugin/framework/server_mux.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// HandlerInitializer is a function that initializes and returns a new instance of one of Velero's plugin interfaces
+// (ObjectStore, BlockStore, BackupItemAction, RestoreItemAction).
+type HandlerInitializer func(logger logrus.FieldLogger) (interface{}, error)
+
+// serverMux manages multiple implementations of a single plugin kind, such as pod and pvc ItemActions for backups.
+type ServerMux struct {
+	kind         PluginKind
+	initializers map[string]HandlerInitializer
+	Handlers     map[string]interface{}
+	ServerLog    logrus.FieldLogger
+}
+
+// newServerMux returns a new serverMux.
+func newServerMux(logger logrus.FieldLogger) *ServerMux {
+	return &ServerMux{
+		initializers: make(map[string]HandlerInitializer),
+		Handlers:     make(map[string]interface{}),
+		ServerLog:    logger,
+	}
+}
+
+// register registers the initializer for name.
+func (m *ServerMux) register(name string, f HandlerInitializer) {
+	// TODO(ncdc): return an error on duplicate registrations for the same name.
+	m.initializers[name] = f
+}
+
+// names returns a list of all registered implementations.
+func (m *ServerMux) names() []string {
+	return sets.StringKeySet(m.initializers).List()
+}
+
+// GetHandler returns the instance for a plugin with the given name. If an instance has already been initialized,
+// that is returned. Otherwise, the instance is initialized by calling its initialization function.
+func (m *ServerMux) GetHandler(name string) (interface{}, error) {
+	if instance, found := m.Handlers[name]; found {
+		return instance, nil
+	}
+
+	initializer, found := m.initializers[name]
+	if !found {
+		return nil, errors.Errorf("unknown %v plugin: %s", m.kind, name)
+	}
+
+	instance, err := initializer(m.ServerLog)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Handlers[name] = instance
+
+	return m.Handlers[name], nil
+}

--- a/pkg/plugin/framework/stream_reader.go
+++ b/pkg/plugin/framework/stream_reader.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"io"
+)
+
+// ReceiveFunc is a function that either returns a slice
+// of an arbitrary number of bytes OR an error. Returning
+// an io.EOF means there is no more data to be read; any
+// other error is considered an actual error.
+type ReceiveFunc func() ([]byte, error)
+
+// CloseFunc is used to signal to the source of data that
+// the StreamReadCloser has been closed.
+type CloseFunc func() error
+
+// StreamReadCloser wraps a ReceiveFunc and a CloseSendFunc
+// to implement io.ReadCloser.
+type StreamReadCloser struct {
+	buf       *bytes.Buffer
+	Receive   ReceiveFunc
+	CloseFunc CloseFunc
+}
+
+func (s *StreamReadCloser) Read(p []byte) (n int, err error) {
+	for {
+		// if buf exists and holds at least as much as we're trying to read,
+		// read from the buffer
+		if s.buf != nil && s.buf.Len() >= len(p) {
+			return s.buf.Read(p)
+		}
+
+		// if buf is nil, create it
+		if s.buf == nil {
+			s.buf = new(bytes.Buffer)
+		}
+
+		// buf exists but doesn't hold enough data to fill p, so
+		// receive again. If we get an EOF, return what's in the
+		// buffer; else, write the new data to the buffer and
+		// try another read.
+		data, err := s.Receive()
+		if err == io.EOF {
+			return s.buf.Read(p)
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		if _, err := s.buf.Write(data); err != nil {
+			return 0, err
+		}
+	}
+}
+
+func (s *StreamReadCloser) Close() error {
+	return s.CloseFunc()
+}

--- a/pkg/plugin/restore/restore_item_action.go
+++ b/pkg/plugin/restore/restore_item_action.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"encoding/json"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/plugin/framework"
+	proto "github.com/heptio/velero/pkg/plugin/generated"
+	"github.com/heptio/velero/pkg/restore"
+)
+
+// ItemActionPlugin is an implementation of go-plugin's Plugin
+// interface with support for gRPC for the restore/ItemAction
+// interface.
+type ItemActionPlugin struct {
+	plugin.NetRPCUnsupportedPlugin
+	*framework.PluginBase
+}
+
+// NewRestoreItemActionPlugin constructs a ItemActionPlugin for restores.
+func NewRestoreItemActionPlugin(options ...framework.PluginOption) *ItemActionPlugin {
+	return &ItemActionPlugin{
+		PluginBase: framework.NewPluginBase(options...),
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// client code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCClient returns a ItemActionPlugin gRPC client for restore.
+func (p *ItemActionPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return framework.NewClientDispenser(p.ClientLogger, c, newRestoreItemActionGRPCClient), nil
+}
+
+// ItemActionGRPCClient implements the backup/ItemAction interface and uses a
+// gRPC client to make calls to the plugin server.
+type ItemActionGRPCClient struct {
+	*framework.ClientBase
+	grpcClient proto.RestoreItemActionClient
+}
+
+func newRestoreItemActionGRPCClient(base *framework.ClientBase, clientConn *grpc.ClientConn) interface{} {
+	return &ItemActionGRPCClient{
+		ClientBase: base,
+		grpcClient: proto.NewRestoreItemActionClient(clientConn),
+	}
+}
+
+func (c *ItemActionGRPCClient) AppliesTo() (restore.ResourceSelector, error) {
+	res, err := c.grpcClient.AppliesTo(context.Background(), &proto.AppliesToRequest{Plugin: c.Plugin})
+	if err != nil {
+		return restore.ResourceSelector{}, err
+	}
+
+	return restore.ResourceSelector{
+		IncludedNamespaces: res.IncludedNamespaces,
+		ExcludedNamespaces: res.ExcludedNamespaces,
+		IncludedResources:  res.IncludedResources,
+		ExcludedResources:  res.ExcludedResources,
+		LabelSelector:      res.Selector,
+	}, nil
+}
+
+func (c *ItemActionGRPCClient) Execute(item runtime.Unstructured, restore *api.Restore) (runtime.Unstructured, error, error) {
+	itemJSON, err := json.Marshal(item.UnstructuredContent())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	restoreJSON, err := json.Marshal(restore)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req := &proto.RestoreExecuteRequest{
+		Plugin:  c.Plugin,
+		Item:    itemJSON,
+		Restore: restoreJSON,
+	}
+
+	res, err := c.grpcClient.Execute(context.Background(), req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var updatedItem unstructured.Unstructured
+	if err := json.Unmarshal(res.Item, &updatedItem); err != nil {
+		return nil, nil, err
+	}
+
+	var warning error
+	if res.Warning != "" {
+		warning = errors.New(res.Warning)
+	}
+
+	return &updatedItem, warning, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// server code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCServer registers a RestoreItemAction gRPC server.
+func (p *ItemActionPlugin) GRPCServer(s *grpc.Server) error {
+	proto.RegisterRestoreItemActionServer(s, &RestoreItemActionGRPCServer{mux: p.ServerMux})
+	return nil
+}
+
+// RestoreItemActionGRPCServer implements the proto-generated RestoreItemActionServer interface, and accepts
+// gRPC calls and forwards them to an implementation of the pluggable interface.
+type RestoreItemActionGRPCServer struct {
+	mux *framework.ServerMux
+}
+
+func (s *RestoreItemActionGRPCServer) getImpl(name string) (restore.ItemAction, error) {
+	impl, err := s.mux.GetHandler(name)
+	if err != nil {
+		return nil, err
+	}
+
+	itemAction, ok := impl.(restore.ItemAction)
+	if !ok {
+		return nil, errors.Errorf("%T is not a restore item action", impl)
+	}
+
+	return itemAction, nil
+}
+
+func (s *RestoreItemActionGRPCServer) AppliesTo(ctx context.Context, req *proto.AppliesToRequest) (*proto.AppliesToResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	appliesTo, err := impl.AppliesTo()
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.AppliesToResponse{
+		IncludedNamespaces: appliesTo.IncludedNamespaces,
+		ExcludedNamespaces: appliesTo.ExcludedNamespaces,
+		IncludedResources:  appliesTo.IncludedResources,
+		ExcludedResources:  appliesTo.ExcludedResources,
+		Selector:           appliesTo.LabelSelector,
+	}, nil
+}
+
+func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *proto.RestoreExecuteRequest) (*proto.RestoreExecuteResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		item    unstructured.Unstructured
+		restore api.Restore
+	)
+
+	if err := json.Unmarshal(req.Item, &item); err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(req.Restore, &restore); err != nil {
+		return nil, err
+	}
+
+	res, warning, err := impl.Execute(&item, &restore)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedItem, err := json.Marshal(res)
+	if err != nil {
+		return nil, err
+	}
+
+	var warnMessage string
+	if warning != nil {
+		warnMessage = warning.Error()
+	}
+
+	return &proto.RestoreExecuteResponse{
+		Item:    updatedItem,
+		Warning: warnMessage,
+	}, nil
+}

--- a/pkg/plugin/storage/object_store.go
+++ b/pkg/plugin/storage/object_store.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"io"
+	"time"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/heptio/velero/pkg/cloudprovider"
+	"github.com/heptio/velero/pkg/plugin/framework"
+	proto "github.com/heptio/velero/pkg/plugin/generated"
+)
+
+const byteChunkSize = 16384
+
+// ObjectStorePlugin is an implementation of go-plugin's Plugin
+// interface with support for gRPC for the cloudprovider/ObjectStore
+// interface.
+type ObjectStorePlugin struct {
+	plugin.NetRPCUnsupportedPlugin
+	*framework.PluginBase
+}
+
+// NewObjectStorePlugin construct an ObjectStorePlugin.
+func NewObjectStorePlugin(options ...framework.PluginOption) *ObjectStorePlugin {
+	return &ObjectStorePlugin{
+		PluginBase: framework.NewPluginBase(options...),
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// client code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCClient returns an ObjectStore gRPC client.
+func (p *ObjectStorePlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return framework.NewClientDispenser(p.ClientLogger, c, newObjectStoreGRPCClient), nil
+
+}
+
+// ObjectStoreGRPCClient implements the cloudprovider.ObjectStore interface and uses a
+// gRPC client to make calls to the plugin server.
+type ObjectStoreGRPCClient struct {
+	*framework.ClientBase
+	grpcClient proto.ObjectStoreClient
+}
+
+func newObjectStoreGRPCClient(base *framework.ClientBase, clientConn *grpc.ClientConn) interface{} {
+	return &ObjectStoreGRPCClient{
+		ClientBase: base,
+		grpcClient: proto.NewObjectStoreClient(clientConn),
+	}
+}
+
+// Init prepares the ObjectStore for usage using the provided map of
+// configuration key-value pairs. It returns an error if the ObjectStore
+// cannot be initialized from the provided config.
+func (c *ObjectStoreGRPCClient) Init(config map[string]string) error {
+	_, err := c.grpcClient.Init(context.Background(), &proto.InitRequest{Plugin: c.Plugin, Config: config})
+
+	return err
+}
+
+// PutObject creates a new object using the data in body within the specified
+// object storage bucket with the given key.
+func (c *ObjectStoreGRPCClient) PutObject(bucket, key string, body io.Reader) error {
+	stream, err := c.grpcClient.PutObject(context.Background())
+	if err != nil {
+		return err
+	}
+
+	// read from the provider io.Reader into chunks, and send each one over
+	// the gRPC stream
+	chunk := make([]byte, byteChunkSize)
+	for {
+		n, err := body.Read(chunk)
+		if err == io.EOF {
+			_, resErr := stream.CloseAndRecv()
+			return resErr
+		}
+		if err != nil {
+			stream.CloseSend()
+			return err
+		}
+
+		if err := stream.Send(&proto.PutObjectRequest{Plugin: c.Plugin, Bucket: bucket, Key: key, Body: chunk[0:n]}); err != nil {
+			return err
+		}
+	}
+}
+
+// GetObject retrieves the object with the given key from the specified
+// bucket in object storage.
+func (c *ObjectStoreGRPCClient) GetObject(bucket, key string) (io.ReadCloser, error) {
+	stream, err := c.grpcClient.GetObject(context.Background(), &proto.GetObjectRequest{Plugin: c.Plugin, Bucket: bucket, Key: key})
+	if err != nil {
+		return nil, err
+	}
+
+	receive := func() ([]byte, error) {
+		data, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+
+		return data.Data, nil
+	}
+
+	close := func() error {
+		return stream.CloseSend()
+	}
+
+	return &framework.StreamReadCloser{Receive: receive, CloseFunc: close}, nil
+}
+
+// ListCommonPrefixes gets a list of all object key prefixes that come
+// after the provided prefix and before the provided delimiter (this is
+// often used to simulate a directory hierarchy in object storage).
+func (c *ObjectStoreGRPCClient) ListCommonPrefixes(bucket, prefix, delimiter string) ([]string, error) {
+	req := &proto.ListCommonPrefixesRequest{
+		Plugin:    c.Plugin,
+		Bucket:    bucket,
+		Prefix:    prefix,
+		Delimiter: delimiter,
+	}
+
+	res, err := c.grpcClient.ListCommonPrefixes(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Prefixes, nil
+}
+
+// ListObjects gets a list of all objects in bucket that have the same prefix.
+func (c *ObjectStoreGRPCClient) ListObjects(bucket, prefix string) ([]string, error) {
+	res, err := c.grpcClient.ListObjects(context.Background(), &proto.ListObjectsRequest{Plugin: c.Plugin, Bucket: bucket, Prefix: prefix})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Keys, nil
+}
+
+// DeleteObject removes object with the specified key from the given
+// bucket.
+func (c *ObjectStoreGRPCClient) DeleteObject(bucket, key string) error {
+	_, err := c.grpcClient.DeleteObject(context.Background(), &proto.DeleteObjectRequest{Plugin: c.Plugin, Bucket: bucket, Key: key})
+
+	return err
+}
+
+// CreateSignedURL creates a pre-signed URL for the given bucket and key that expires after ttl.
+func (c *ObjectStoreGRPCClient) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
+	res, err := c.grpcClient.CreateSignedURL(context.Background(), &proto.CreateSignedURLRequest{
+		Plugin: c.Plugin,
+		Bucket: bucket,
+		Key:    key,
+		Ttl:    int64(ttl),
+	})
+	if err != nil {
+		return "", nil
+	}
+
+	return res.Url, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// server code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCServer registers an ObjectStore gRPC server.
+func (p *ObjectStorePlugin) GRPCServer(s *grpc.Server) error {
+	proto.RegisterObjectStoreServer(s, &ObjectStoreGRPCServer{mux: p.ServerMux})
+	return nil
+}
+
+// ObjectStoreGRPCServer implements the proto-generated ObjectStoreServer interface, and accepts
+// gRPC calls and forwards them to an implementation of the pluggable interface.
+type ObjectStoreGRPCServer struct {
+	mux *framework.ServerMux
+}
+
+func (s *ObjectStoreGRPCServer) getImpl(name string) (cloudprovider.ObjectStore, error) {
+	impl, err := s.mux.GetHandler(name)
+	if err != nil {
+		return nil, err
+	}
+
+	itemAction, ok := impl.(cloudprovider.ObjectStore)
+	if !ok {
+		return nil, errors.Errorf("%T is not an object store", impl)
+	}
+
+	return itemAction, nil
+}
+
+// Init prepares the ObjectStore for usage using the provided map of
+// configuration key-value pairs. It returns an error if the ObjectStore
+// cannot be initialized from the provided config.
+func (s *ObjectStoreGRPCServer) Init(ctx context.Context, req *proto.InitRequest) (*proto.Empty, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := impl.Init(req.Config); err != nil {
+		return nil, err
+	}
+
+	return &proto.Empty{}, nil
+}
+
+// PutObject creates a new object using the data in body within the specified
+// object storage bucket with the given key.
+func (s *ObjectStoreGRPCServer) PutObject(stream proto.ObjectStore_PutObjectServer) error {
+	// we need to read the first chunk ahead of time to get the bucket and key;
+	// in our receive method, we'll use `first` on the first call
+	firstChunk, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	impl, err := s.getImpl(firstChunk.Plugin)
+	if err != nil {
+		return err
+	}
+
+	bucket := firstChunk.Bucket
+	key := firstChunk.Key
+
+	receive := func() ([]byte, error) {
+		if firstChunk != nil {
+			res := firstChunk.Body
+			firstChunk = nil
+			return res, nil
+		}
+
+		data, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		return data.Body, nil
+	}
+
+	close := func() error {
+		return nil
+	}
+
+	if err := impl.PutObject(bucket, key, &framework.StreamReadCloser{Receive: receive, CloseFunc: close}); err != nil {
+		return err
+	}
+
+	return stream.SendAndClose(&proto.Empty{})
+}
+
+// GetObject retrieves the object with the given key from the specified
+// bucket in object storage.
+func (s *ObjectStoreGRPCServer) GetObject(req *proto.GetObjectRequest, stream proto.ObjectStore_GetObjectServer) error {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return err
+	}
+
+	rdr, err := impl.GetObject(req.Bucket, req.Key)
+	if err != nil {
+		return err
+	}
+	defer rdr.Close()
+
+	chunk := make([]byte, byteChunkSize)
+	for {
+		n, err := rdr.Read(chunk)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+
+		if err := stream.Send(&proto.Bytes{Data: chunk[0:n]}); err != nil {
+			return err
+		}
+	}
+}
+
+// ListCommonPrefixes gets a list of all object key prefixes that start with
+// the specified prefix and stop at the next instance of the provided delimiter
+// (this is often used to simulate a directory hierarchy in object storage).
+func (s *ObjectStoreGRPCServer) ListCommonPrefixes(ctx context.Context, req *proto.ListCommonPrefixesRequest) (*proto.ListCommonPrefixesResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	prefixes, err := impl.ListCommonPrefixes(req.Bucket, req.Prefix, req.Delimiter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.ListCommonPrefixesResponse{Prefixes: prefixes}, nil
+}
+
+// ListObjects gets a list of all objects in bucket that have the same prefix.
+func (s *ObjectStoreGRPCServer) ListObjects(ctx context.Context, req *proto.ListObjectsRequest) (*proto.ListObjectsResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := impl.ListObjects(req.Bucket, req.Prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.ListObjectsResponse{Keys: keys}, nil
+}
+
+// DeleteObject removes object with the specified key from the given
+// bucket.
+func (s *ObjectStoreGRPCServer) DeleteObject(ctx context.Context, req *proto.DeleteObjectRequest) (*proto.Empty, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := impl.DeleteObject(req.Bucket, req.Key); err != nil {
+		return nil, err
+	}
+
+	return &proto.Empty{}, nil
+}
+
+// CreateSignedURL creates a pre-signed URL for the given bucket and key that expires after ttl.
+func (s *ObjectStoreGRPCServer) CreateSignedURL(ctx context.Context, req *proto.CreateSignedURLRequest) (*proto.CreateSignedURLResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := impl.CreateSignedURL(req.Bucket, req.Key, time.Duration(req.Ttl))
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.CreateSignedURLResponse{Url: url}, nil
+}

--- a/pkg/plugin/volume/block_store.go
+++ b/pkg/plugin/volume/block_store.go
@@ -1,0 +1,359 @@
+/*
+Copyright 2017 the Heptio Ark contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/heptio/velero/pkg/cloudprovider"
+	"github.com/heptio/velero/pkg/plugin/framework"
+	proto "github.com/heptio/velero/pkg/plugin/generated"
+)
+
+// BlockStorePlugin is an implementation of go-plugin's Plugin
+// interface with support for gRPC for the cloudprovider/BlockStore
+// interface.
+type BlockStorePlugin struct {
+	plugin.NetRPCUnsupportedPlugin
+	*framework.PluginBase
+}
+
+// NewBlockStorePlugin constructs a BlockStorePlugin.
+func NewBlockStorePlugin(options ...framework.PluginOption) *BlockStorePlugin {
+	return &BlockStorePlugin{
+		PluginBase: framework.NewPluginBase(options...),
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// client code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCClient returns a BlockStore gRPC client.
+func (p *BlockStorePlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return framework.NewClientDispenser(p.ClientLogger, c, newBlockStoreGRPCClient), nil
+}
+
+// BlockStoreGRPCClient implements the cloudprovider.BlockStore interface and uses a
+// gRPC client to make calls to the plugin server.
+type BlockStoreGRPCClient struct {
+	*framework.ClientBase
+	grpcClient proto.BlockStoreClient
+}
+
+func newBlockStoreGRPCClient(base *framework.ClientBase, clientConn *grpc.ClientConn) interface{} {
+	return &BlockStoreGRPCClient{
+		ClientBase: base,
+		grpcClient: proto.NewBlockStoreClient(clientConn),
+	}
+}
+
+// Init prepares the BlockStore for usage using the provided map of
+// configuration key-value pairs. It returns an error if the BlockStore
+// cannot be initialized from the provided config.
+func (c *BlockStoreGRPCClient) Init(config map[string]string) error {
+	_, err := c.grpcClient.Init(context.Background(), &proto.InitRequest{Plugin: c.Plugin, Config: config})
+
+	return err
+}
+
+// CreateVolumeFromSnapshot creates a new block volume, initialized from the provided snapshot,
+// and with the specified type and IOPS (if using provisioned IOPS).
+func (c *BlockStoreGRPCClient) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ string, iops *int64) (string, error) {
+	req := &proto.CreateVolumeRequest{
+		Plugin:     c.Plugin,
+		SnapshotID: snapshotID,
+		VolumeType: volumeType,
+		VolumeAZ:   volumeAZ,
+	}
+
+	if iops == nil {
+		req.Iops = 0
+	} else {
+		req.Iops = *iops
+	}
+
+	res, err := c.grpcClient.CreateVolumeFromSnapshot(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.VolumeID, nil
+}
+
+// GetVolumeInfo returns the type and IOPS (if using provisioned IOPS) for a specified block
+// volume.
+func (c *BlockStoreGRPCClient) GetVolumeInfo(volumeID, volumeAZ string) (string, *int64, error) {
+	res, err := c.grpcClient.GetVolumeInfo(context.Background(), &proto.GetVolumeInfoRequest{Plugin: c.Plugin, VolumeID: volumeID, VolumeAZ: volumeAZ})
+	if err != nil {
+		return "", nil, err
+	}
+
+	var iops *int64
+	if res.Iops != 0 {
+		iops = &res.Iops
+	}
+
+	return res.VolumeType, iops, nil
+}
+
+// CreateSnapshot creates a snapshot of the specified block volume, and applies the provided
+// set of tags to the snapshot.
+func (c *BlockStoreGRPCClient) CreateSnapshot(volumeID, volumeAZ string, tags map[string]string) (string, error) {
+	req := &proto.CreateSnapshotRequest{
+		Plugin:   c.Plugin,
+		VolumeID: volumeID,
+		VolumeAZ: volumeAZ,
+		Tags:     tags,
+	}
+
+	res, err := c.grpcClient.CreateSnapshot(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.SnapshotID, nil
+}
+
+// DeleteSnapshot deletes the specified volume snapshot.
+func (c *BlockStoreGRPCClient) DeleteSnapshot(snapshotID string) error {
+	_, err := c.grpcClient.DeleteSnapshot(context.Background(), &proto.DeleteSnapshotRequest{Plugin: c.Plugin, SnapshotID: snapshotID})
+
+	return err
+}
+
+func (c *BlockStoreGRPCClient) GetVolumeID(pv runtime.Unstructured) (string, error) {
+	encodedPV, err := json.Marshal(pv.UnstructuredContent())
+	if err != nil {
+		return "", err
+	}
+
+	req := &proto.GetVolumeIDRequest{
+		Plugin:           c.Plugin,
+		PersistentVolume: encodedPV,
+	}
+
+	resp, err := c.grpcClient.GetVolumeID(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.VolumeID, nil
+}
+
+func (c *BlockStoreGRPCClient) SetVolumeID(pv runtime.Unstructured, volumeID string) (runtime.Unstructured, error) {
+	encodedPV, err := json.Marshal(pv.UnstructuredContent())
+	if err != nil {
+		return nil, err
+	}
+
+	req := &proto.SetVolumeIDRequest{
+		Plugin:           c.Plugin,
+		PersistentVolume: encodedPV,
+		VolumeID:         volumeID,
+	}
+
+	resp, err := c.grpcClient.SetVolumeID(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	var updatedPV unstructured.Unstructured
+	if err := json.Unmarshal(resp.PersistentVolume, &updatedPV); err != nil {
+		return nil, err
+
+	}
+
+	return &updatedPV, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// server code
+//////////////////////////////////////////////////////////////////////////////
+
+// GRPCServer registers a BlockStore gRPC server.
+func (p *BlockStorePlugin) GRPCServer(s *grpc.Server) error {
+	proto.RegisterBlockStoreServer(s, &BlockStoreGRPCServer{mux: p.ServerMux})
+	return nil
+}
+
+// BlockStoreGRPCServer implements the proto-generated BlockStoreServer interface, and accepts
+// gRPC calls and forwards them to an implementation of the pluggable interface.
+type BlockStoreGRPCServer struct {
+	mux *framework.ServerMux
+}
+
+func (s *BlockStoreGRPCServer) getImpl(name string) (cloudprovider.BlockStore, error) {
+	impl, err := s.mux.GetHandler(name)
+	if err != nil {
+		return nil, err
+	}
+
+	blockStore, ok := impl.(cloudprovider.BlockStore)
+	if !ok {
+		return nil, errors.Errorf("%T is not a block store", impl)
+	}
+
+	return blockStore, nil
+}
+
+// Init prepares the BlockStore for usage using the provided map of
+// configuration key-value pairs. It returns an error if the BlockStore
+// cannot be initialized from the provided config.
+func (s *BlockStoreGRPCServer) Init(ctx context.Context, req *proto.InitRequest) (*proto.Empty, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := impl.Init(req.Config); err != nil {
+		return nil, err
+	}
+
+	return &proto.Empty{}, nil
+}
+
+// CreateVolumeFromSnapshot creates a new block volume, initialized from the provided snapshot,
+// and with the specified type and IOPS (if using provisioned IOPS).
+func (s *BlockStoreGRPCServer) CreateVolumeFromSnapshot(ctx context.Context, req *proto.CreateVolumeRequest) (*proto.CreateVolumeResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotID := req.SnapshotID
+	volumeType := req.VolumeType
+	volumeAZ := req.VolumeAZ
+	var iops *int64
+
+	if req.Iops != 0 {
+		iops = &req.Iops
+	}
+
+	volumeID, err := impl.CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ, iops)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.CreateVolumeResponse{VolumeID: volumeID}, nil
+}
+
+// GetVolumeInfo returns the type and IOPS (if using provisioned IOPS) for a specified block
+// volume.
+func (s *BlockStoreGRPCServer) GetVolumeInfo(ctx context.Context, req *proto.GetVolumeInfoRequest) (*proto.GetVolumeInfoResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeType, iops, err := impl.GetVolumeInfo(req.VolumeID, req.VolumeAZ)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &proto.GetVolumeInfoResponse{
+		VolumeType: volumeType,
+	}
+
+	if iops != nil {
+		res.Iops = *iops
+	}
+
+	return res, nil
+}
+
+// CreateSnapshot creates a snapshot of the specified block volume, and applies the provided
+// set of tags to the snapshot.
+func (s *BlockStoreGRPCServer) CreateSnapshot(ctx context.Context, req *proto.CreateSnapshotRequest) (*proto.CreateSnapshotResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotID, err := impl.CreateSnapshot(req.VolumeID, req.VolumeAZ, req.Tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.CreateSnapshotResponse{SnapshotID: snapshotID}, nil
+}
+
+// DeleteSnapshot deletes the specified volume snapshot.
+func (s *BlockStoreGRPCServer) DeleteSnapshot(ctx context.Context, req *proto.DeleteSnapshotRequest) (*proto.Empty, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := impl.DeleteSnapshot(req.SnapshotID); err != nil {
+		return nil, err
+	}
+
+	return &proto.Empty{}, nil
+}
+
+func (s *BlockStoreGRPCServer) GetVolumeID(ctx context.Context, req *proto.GetVolumeIDRequest) (*proto.GetVolumeIDResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	var pv unstructured.Unstructured
+
+	if err := json.Unmarshal(req.PersistentVolume, &pv); err != nil {
+		return nil, err
+	}
+
+	volumeID, err := impl.GetVolumeID(&pv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.GetVolumeIDResponse{VolumeID: volumeID}, nil
+}
+
+func (s *BlockStoreGRPCServer) SetVolumeID(ctx context.Context, req *proto.SetVolumeIDRequest) (*proto.SetVolumeIDResponse, error) {
+	impl, err := s.getImpl(req.Plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	var pv unstructured.Unstructured
+
+	if err := json.Unmarshal(req.PersistentVolume, &pv); err != nil {
+		return nil, err
+	}
+
+	updatedPV, err := impl.SetVolumeID(&pv, req.VolumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPVBytes, err := json.Marshal(updatedPV.UnstructuredContent())
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.SetVolumeIDResponse{PersistentVolume: updatedPVBytes}, nil
+}


### PR DESCRIPTION
This is a continuation of https://github.com/heptio/velero/pull/1147.

Highlights:
- This PR moves all the plugin interfaces and their dependencies into their own separate packages.
- All the code at this point has been duplicated; changing the code to consume these interfaces where they are now will be done in a separate PR or an amendment to this PR
- to avoid "stuttering", BackupItemAction and RestoreItemAction are not both named ItemAction; also, the code in those files are almost identical! I wonder if we could optimize this.
- the directory `pkg/plugin/framework` will have more files (like server.go and logger.go) after the code is changed to point to these new packages. I left anything that wasn't a dependency out for now.

Signed-off-by: Carlisia <carlisiac@vmware.com>