### PR TITLE
pass --log-level to plugins

### DIFF
--- a/changelogs/unreleased/1278-skriss
+++ b/changelogs/unreleased/1278-skriss
@@ -1,0 +1,1 @@
+Pass --log-level flag to internal/external plugins, matching Velero server's log level

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,8 +22,9 @@ Velero currently supports the following kinds of plugins:
 ## Plugin Logging
 
 Velero provides a [logger][2] that can be used by plugins to log structured information to the main Velero server log or 
-per-backup/restore logs. See the [sample repository][1] for an example of how to instantiate and use the logger 
-within your plugin.
+per-backup/restore logs. It also passes a `--log-level` flag to each plugin binary, whose value is the value of the same 
+flag from the main Velero process. This means that if you turn on debug logging for the Velero server via `--log-level=debug`, 
+plugins will also emit debug-level logs. See the [sample repository][1] for an example of how to use the logger within your plugin.
 
 
 

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Heptio Ark contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -17,9 +17,6 @@ limitations under the License.
 package plugin
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -31,25 +28,16 @@ import (
 	velerodiscovery "github.com/heptio/velero/pkg/discovery"
 	veleroplugin "github.com/heptio/velero/pkg/plugin"
 	"github.com/heptio/velero/pkg/restore"
-	"github.com/heptio/velero/pkg/util/logging"
 )
 
 func NewCommand(f client.Factory) *cobra.Command {
-	logLevelFlag := logging.LogLevelFlag(logrus.InfoLevel)
-
+	pluginServer := veleroplugin.NewServer()
 	c := &cobra.Command{
 		Use:    "run-plugins",
 		Hidden: true,
 		Short:  "INTERNAL COMMAND ONLY - not intended to be run directly by users",
 		Run: func(c *cobra.Command, args []string) {
-			logLevel := logLevelFlag.Parse()
-			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
-
-			logger := veleroplugin.NewLogger(logLevel)
-
-			logger.Debug("Executing run-plugins command")
-
-			veleroplugin.NewServer(logger).
+			pluginServer.
 				RegisterObjectStore("aws", newAwsObjectStore).
 				RegisterObjectStore("azure", newAzureObjectStore).
 				RegisterObjectStore("gcp", newGcpObjectStore).
@@ -68,7 +56,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		},
 	}
 
-	c.Flags().Var(logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(logLevelFlag.AllowedValues(), ", ")))
+	pluginServer.BindFlags(c.Flags())
 
 	return c
 }

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -17,6 +17,9 @@ limitations under the License.
 package plugin
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -28,16 +31,22 @@ import (
 	velerodiscovery "github.com/heptio/velero/pkg/discovery"
 	veleroplugin "github.com/heptio/velero/pkg/plugin"
 	"github.com/heptio/velero/pkg/restore"
+	"github.com/heptio/velero/pkg/util/logging"
 )
 
 func NewCommand(f client.Factory) *cobra.Command {
-	logger := veleroplugin.NewLogger()
+	logLevelFlag := logging.LogLevelFlag(logrus.InfoLevel)
 
 	c := &cobra.Command{
 		Use:    "run-plugins",
 		Hidden: true,
 		Short:  "INTERNAL COMMAND ONLY - not intended to be run directly by users",
 		Run: func(c *cobra.Command, args []string) {
+			logLevel := logLevelFlag.Parse()
+			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))
+
+			logger := veleroplugin.NewLogger(logLevel)
+
 			logger.Debug("Executing run-plugins command")
 
 			veleroplugin.NewServer(logger).
@@ -58,6 +67,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 				Serve()
 		},
 	}
+
+	c.Flags().Var(logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(logLevelFlag.AllowedValues(), ", ")))
 
 	return c
 }

--- a/pkg/plugin/client_builder.go
+++ b/pkg/plugin/client_builder.go
@@ -42,8 +42,11 @@ func newClientBuilder(command string, logger logrus.FieldLogger, logLevel logrus
 	}
 	if command == os.Args[0] {
 		// For plugins compiled into the velero executable, we need to run "velero run-plugins"
-		b.commandArgs = []string{"run-plugins", "--log-level", logLevel.String()}
+		b.commandArgs = []string{"run-plugins"}
 	}
+
+	b.commandArgs = append(b.commandArgs, "--log-level", logLevel.String())
+
 	return b
 }
 

--- a/pkg/plugin/client_builder.go
+++ b/pkg/plugin/client_builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Heptio Ark contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/plugin/client_builder.go
+++ b/pkg/plugin/client_builder.go
@@ -42,7 +42,7 @@ func newClientBuilder(command string, logger logrus.FieldLogger, logLevel logrus
 	}
 	if command == os.Args[0] {
 		// For plugins compiled into the velero executable, we need to run "velero run-plugins"
-		b.commandArgs = []string{"run-plugins"}
+		b.commandArgs = []string{"run-plugins", "--log-level", logLevel.String()}
 	}
 	return b
 }

--- a/pkg/plugin/client_builder_test.go
+++ b/pkg/plugin/client_builder_test.go
@@ -32,7 +32,7 @@ func TestNewClientBuilder(t *testing.T) {
 	logLevel := logrus.InfoLevel
 	cb := newClientBuilder("velero", logger, logLevel)
 	assert.Equal(t, cb.commandName, "velero")
-	assert.Empty(t, cb.commandArgs)
+	assert.Equal(t, []string{"--log-level", "info"}, cb.commandArgs)
 	assert.Equal(t, newLogrusAdapter(logger, logLevel), cb.pluginLogger)
 
 	cb = newClientBuilder(os.Args[0], logger, logLevel)

--- a/pkg/plugin/client_builder_test.go
+++ b/pkg/plugin/client_builder_test.go
@@ -37,7 +37,7 @@ func TestNewClientBuilder(t *testing.T) {
 
 	cb = newClientBuilder(os.Args[0], logger, logLevel)
 	assert.Equal(t, cb.commandName, os.Args[0])
-	assert.Equal(t, []string{"run-plugins"}, cb.commandArgs)
+	assert.Equal(t, []string{"run-plugins", "--log-level", "info"}, cb.commandArgs)
 	assert.Equal(t, newLogrusAdapter(logger, logLevel), cb.pluginLogger)
 }
 

--- a/pkg/plugin/client_builder_test.go
+++ b/pkg/plugin/client_builder_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Heptio Ark contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/plugin/logger.go
+++ b/pkg/plugin/logger.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Heptio Ark contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/plugin/logger.go
+++ b/pkg/plugin/logger.go
@@ -22,11 +22,10 @@ import (
 	"github.com/heptio/velero/pkg/util/logging"
 )
 
-// NewLogger returns a logger that is suitable for use within an
+// newLogger returns a logger that is suitable for use within an
 // Velero plugin.
-func NewLogger(level logrus.Level) logrus.FieldLogger {
+func newLogger() *logrus.Logger {
 	logger := logrus.New()
-	logger.Level = level
 	/*
 		!!!DO NOT SET THE OUTPUT TO STDOUT!!!
 

--- a/pkg/plugin/logger.go
+++ b/pkg/plugin/logger.go
@@ -24,8 +24,9 @@ import (
 
 // NewLogger returns a logger that is suitable for use within an
 // Velero plugin.
-func NewLogger() logrus.FieldLogger {
+func NewLogger(level logrus.Level) logrus.FieldLogger {
 	logger := logrus.New()
+	logger.Level = level
 	/*
 		!!!DO NOT SET THE OUTPUT TO STDOUT!!!
 

--- a/pkg/plugin/logger_test.go
+++ b/pkg/plugin/logger_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Heptio Ark contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/plugin/logger_test.go
+++ b/pkg/plugin/logger_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNewLogger(t *testing.T) {
-	l := NewLogger(logrus.InfoLevel).(*logrus.Logger)
+	l := newLogger()
 
 	expectedFormatter := &logrus.JSONFormatter{
 		FieldMap: logrus.FieldMap{

--- a/pkg/plugin/logger_test.go
+++ b/pkg/plugin/logger_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNewLogger(t *testing.T) {
-	l := NewLogger().(*logrus.Logger)
+	l := NewLogger(logrus.InfoLevel).(*logrus.Logger)
 
 	expectedFormatter := &logrus.JSONFormatter{
 		FieldMap: logrus.FieldMap{

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -17,10 +17,15 @@ limitations under the License.
 package plugin
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/heptio/velero/pkg/util/logging"
 )
 
 // Handshake is configuration information that allows go-plugin clients and servers to perform a handshake.
@@ -35,6 +40,14 @@ var Handshake = plugin.HandshakeConfig{
 
 // Server serves registered plugin implementations.
 type Server interface {
+	// BindFlags defines the plugin server's command-line flags
+	// on the provided FlagSet. If you're not sure what flag set
+	// to use, pflag.CommandLine is the default set of command-line
+	// flags.
+	//
+	// This method must be called prior to calling .Serve().
+	BindFlags(flags *pflag.FlagSet) Server
+
 	// RegisterBackupItemAction registers a backup item action.
 	RegisterBackupItemAction(name string, initializer HandlerInitializer) Server
 
@@ -65,6 +78,9 @@ type Server interface {
 
 // server implements Server.
 type server struct {
+	log               *logrus.Logger
+	logLevelFlag      *logging.LevelFlag
+	flagSet           *pflag.FlagSet
 	backupItemAction  *BackupItemActionPlugin
 	blockStore        *BlockStorePlugin
 	objectStore       *ObjectStorePlugin
@@ -72,13 +88,24 @@ type server struct {
 }
 
 // NewServer returns a new Server
-func NewServer(log logrus.FieldLogger) Server {
+func NewServer() Server {
+	log := newLogger()
+
 	return &server{
+		log:               log,
 		backupItemAction:  NewBackupItemActionPlugin(serverLogger(log)),
 		blockStore:        NewBlockStorePlugin(serverLogger(log)),
 		objectStore:       NewObjectStorePlugin(serverLogger(log)),
 		restoreItemAction: NewRestoreItemActionPlugin(serverLogger(log)),
 	}
+}
+
+func (s *server) BindFlags(flags *pflag.FlagSet) Server {
+	s.logLevelFlag = logging.LogLevelFlag(s.log.Level)
+	flags.Var(s.logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(s.logLevelFlag.AllowedValues(), ", ")))
+	s.flagSet = flags
+
+	return s
 }
 
 func (s *server) RegisterBackupItemAction(name string, initializer HandlerInitializer) Server {
@@ -142,6 +169,14 @@ func getNames(command string, kind PluginKind, plugin Interface) []PluginIdentif
 }
 
 func (s *server) Serve() {
+	if s.flagSet != nil && !s.flagSet.Parsed() {
+		s.log.Infof("Parsing flags")
+		s.flagSet.Parse(os.Args[1:])
+	}
+
+	s.log.Level = s.logLevelFlag.Parse()
+	s.log.Infof("Setting log level to %s", strings.ToUpper(s.log.Level.String()))
+
 	command := os.Args[0]
 
 	var pluginIdentifiers []PluginIdentifier

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Heptio Ark contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -93,6 +93,7 @@ func NewServer() Server {
 
 	return &server{
 		log:               log,
+		logLevelFlag:      logging.LogLevelFlag(log.Level),
 		backupItemAction:  NewBackupItemActionPlugin(serverLogger(log)),
 		blockStore:        NewBlockStorePlugin(serverLogger(log)),
 		objectStore:       NewObjectStorePlugin(serverLogger(log)),
@@ -101,7 +102,6 @@ func NewServer() Server {
 }
 
 func (s *server) BindFlags(flags *pflag.FlagSet) Server {
-	s.logLevelFlag = logging.LogLevelFlag(s.log.Level)
 	flags.Var(s.logLevelFlag, "log-level", fmt.Sprintf("the level at which to log. Valid values are %s.", strings.Join(s.logLevelFlag.AllowedValues(), ", ")))
 	s.flagSet = flags
 


### PR DESCRIPTION
Fixes #1211
Update of #1049

This PR passes the velero server's log level to all plugins (internal and external) via a `--log-level` flag. It adds helpers to `pkg/plugin.Server` so plugin authors can support this flag with a single line of code.

@nrb @carlisia I did this in a way that should work for plugins that use cobra (e.g. our internal `run-plugins` command) as well as those that don't (e.g. our plugin-example).  Please review this with an eye towards plugin developer experience.

Still doing some testing on this.