### PR TITLE
restic restore helper image can be configured with cli flag

### DIFF
--- a/changelogs/unreleased/1290-ryane
+++ b/changelogs/unreleased/1290-ryane
@@ -1,0 +1,1 @@
+restic restore helper image can be configured with cli flag

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -32,6 +32,9 @@ import (
 
 func NewCommand(f client.Factory) *cobra.Command {
 	pluginServer := veleroplugin.NewServer()
+
+	var resticRestoreHelperImage string
+
 	c := &cobra.Command{
 		Use:    "run-plugins",
 		Hidden: true,
@@ -49,13 +52,14 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterBackupItemAction("serviceaccount", newServiceAccountBackupItemAction(f)).
 				RegisterRestoreItemAction("job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("pod", newPodRestoreItemAction).
-				RegisterRestoreItemAction("restic", newResticRestoreItemAction).
+				RegisterRestoreItemAction("restic", newResticRestoreItemAction(resticRestoreHelperImage)).
 				RegisterRestoreItemAction("service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("serviceaccount", newServiceAccountRestoreItemAction).
 				Serve()
 		},
 	}
 
+	c.Flags().StringVar(&resticRestoreHelperImage, "restic-restore-helper-image", "", "the docker image for the velero restic restore helper")
 	pluginServer.BindFlags(c.Flags())
 
 	return c
@@ -126,8 +130,10 @@ func newPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	return restore.NewPodAction(logger), nil
 }
 
-func newResticRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
-	return restore.NewResticRestoreAction(logger), nil
+func newResticRestoreItemAction(initContainerImage string) veleroplugin.HandlerInitializer {
+	return func(logger logrus.FieldLogger) (interface{}, error) {
+		return restore.NewResticRestoreAction(logger, initContainerImage), nil
+	}
 }
 
 func newServiceRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {

--- a/pkg/plugin/client_builder.go
+++ b/pkg/plugin/client_builder.go
@@ -34,7 +34,7 @@ type clientBuilder struct {
 
 // newClientBuilder returns a new clientBuilder with commandName to name. If the command matches the currently running
 // process (i.e. velero), this also sets commandArgs to the internal Velero command to run plugins.
-func newClientBuilder(command string, logger logrus.FieldLogger, logLevel logrus.Level) *clientBuilder {
+func newClientBuilder(command string, pluginArgs []string, logger logrus.FieldLogger, logLevel logrus.Level) *clientBuilder {
 	b := &clientBuilder{
 		commandName:  command,
 		clientLogger: logger,
@@ -43,6 +43,9 @@ func newClientBuilder(command string, logger logrus.FieldLogger, logLevel logrus
 	if command == os.Args[0] {
 		// For plugins compiled into the velero executable, we need to run "velero run-plugins"
 		b.commandArgs = []string{"run-plugins"}
+		if len(pluginArgs) > 0 {
+			b.commandArgs = append(b.commandArgs, pluginArgs...)
+		}
 	}
 
 	b.commandArgs = append(b.commandArgs, "--log-level", logLevel.String())

--- a/pkg/plugin/client_builder_test.go
+++ b/pkg/plugin/client_builder_test.go
@@ -30,21 +30,26 @@ import (
 func TestNewClientBuilder(t *testing.T) {
 	logger := test.NewLogger()
 	logLevel := logrus.InfoLevel
-	cb := newClientBuilder("velero", logger, logLevel)
+	cb := newClientBuilder("velero", []string{}, logger, logLevel)
 	assert.Equal(t, cb.commandName, "velero")
 	assert.Equal(t, []string{"--log-level", "info"}, cb.commandArgs)
 	assert.Equal(t, newLogrusAdapter(logger, logLevel), cb.pluginLogger)
 
-	cb = newClientBuilder(os.Args[0], logger, logLevel)
+	cb = newClientBuilder(os.Args[0], []string{}, logger, logLevel)
 	assert.Equal(t, cb.commandName, os.Args[0])
 	assert.Equal(t, []string{"run-plugins", "--log-level", "info"}, cb.commandArgs)
+	assert.Equal(t, newLogrusAdapter(logger, logLevel), cb.pluginLogger)
+
+	cb = newClientBuilder(os.Args[0], []string{"additional", "args"}, logger, logLevel)
+	assert.Equal(t, cb.commandName, os.Args[0])
+	assert.Equal(t, []string{"run-plugins", "additional", "args", "--log-level", "info"}, cb.commandArgs)
 	assert.Equal(t, newLogrusAdapter(logger, logLevel), cb.pluginLogger)
 }
 
 func TestClientConfig(t *testing.T) {
 	logger := test.NewLogger()
 	logLevel := logrus.InfoLevel
-	cb := newClientBuilder("velero", logger, logLevel)
+	cb := newClientBuilder("velero", []string{}, logger, logLevel)
 
 	expected := &hcplugin.ClientConfig{
 		HandshakeConfig:  Handshake,

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -62,13 +62,13 @@ type manager struct {
 }
 
 // NewManager constructs a manager for getting plugins.
-func NewManager(logger logrus.FieldLogger, level logrus.Level, registry Registry) Manager {
+func NewManager(logger logrus.FieldLogger, pluginArgs []string, level logrus.Level, registry Registry) Manager {
 	return &manager{
 		logger:   logger,
 		logLevel: level,
 		registry: registry,
 
-		restartableProcessFactory: newRestartableProcessFactory(),
+		restartableProcessFactory: newRestartableProcessFactory(pluginArgs),
 
 		restartableProcesses: make(map[string]RestartableProcess),
 	}

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -59,7 +59,7 @@ func TestNewManager(t *testing.T) {
 	registry := &mockRegistry{}
 	defer registry.AssertExpectations(t)
 
-	m := NewManager(logger, logLevel, registry).(*manager)
+	m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 	assert.Equal(t, logger, m.logger)
 	assert.Equal(t, logLevel, m.logLevel)
 	assert.Equal(t, registry, m.registry)
@@ -114,7 +114,7 @@ func TestGetRestartableProcess(t *testing.T) {
 	registry := &mockRegistry{}
 	defer registry.AssertExpectations(t)
 
-	m := NewManager(logger, logLevel, registry).(*manager)
+	m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 	factory := &mockRestartableProcessFactory{}
 	defer factory.AssertExpectations(t)
 	m.restartableProcessFactory = factory
@@ -160,7 +160,7 @@ func TestCleanupClients(t *testing.T) {
 	registry := &mockRegistry{}
 	defer registry.AssertExpectations(t)
 
-	m := NewManager(logger, logLevel, registry).(*manager)
+	m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 
 	for i := 0; i < 5; i++ {
 		rp := &mockRestartableProcess{}
@@ -254,7 +254,7 @@ func getPluginTest(
 	registry := &mockRegistry{}
 	defer registry.AssertExpectations(t)
 
-	m := NewManager(logger, logLevel, registry).(*manager)
+	m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 	factory := &mockRestartableProcessFactory{}
 	defer factory.AssertExpectations(t)
 	m.restartableProcessFactory = factory
@@ -321,7 +321,7 @@ func TestGetBackupItemActions(t *testing.T) {
 			registry := &mockRegistry{}
 			defer registry.AssertExpectations(t)
 
-			m := NewManager(logger, logLevel, registry).(*manager)
+			m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 			factory := &mockRestartableProcessFactory{}
 			defer factory.AssertExpectations(t)
 			m.restartableProcessFactory = factory
@@ -413,7 +413,7 @@ func TestGetRestoreItemActions(t *testing.T) {
 			registry := &mockRegistry{}
 			defer registry.AssertExpectations(t)
 
-			m := NewManager(logger, logLevel, registry).(*manager)
+			m := NewManager(logger, []string{}, logLevel, registry).(*manager)
 			factory := &mockRestartableProcessFactory{}
 			defer factory.AssertExpectations(t)
 			m.restartableProcessFactory = factory

--- a/pkg/plugin/process.go
+++ b/pkg/plugin/process.go
@@ -26,14 +26,15 @@ type ProcessFactory interface {
 }
 
 type processFactory struct {
+	pluginArgs []string
 }
 
-func newProcessFactory() ProcessFactory {
-	return &processFactory{}
+func newProcessFactory(pluginArgs []string) ProcessFactory {
+	return &processFactory{pluginArgs}
 }
 
 func (pf *processFactory) newProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (Process, error) {
-	return newProcess(command, logger, logLevel)
+	return newProcess(command, pf.pluginArgs, logger, logLevel)
 }
 
 type Process interface {
@@ -47,8 +48,8 @@ type process struct {
 	protocolClient plugin.ClientProtocol
 }
 
-func newProcess(command string, logger logrus.FieldLogger, logLevel logrus.Level) (Process, error) {
-	builder := newClientBuilder(command, logger.WithField("cmd", command), logLevel)
+func newProcess(command string, pluginArgs []string, logger logrus.FieldLogger, logLevel logrus.Level) (Process, error) {
+	builder := newClientBuilder(command, pluginArgs, logger.WithField("cmd", command), logLevel)
 
 	// This creates a new go-plugin Client that has its own unique exec.Cmd for launching the plugin process.
 	client := builder.client()

--- a/pkg/plugin/registry.go
+++ b/pkg/plugin/registry.go
@@ -56,13 +56,13 @@ type registry struct {
 }
 
 // NewRegistry returns a new registry.
-func NewRegistry(dir string, logger logrus.FieldLogger, logLevel logrus.Level) Registry {
+func NewRegistry(dir string, pluginArgs []string, logger logrus.FieldLogger, logLevel logrus.Level) Registry {
 	return &registry{
 		dir:      dir,
 		logger:   logger,
 		logLevel: logLevel,
 
-		processFactory: newProcessFactory(),
+		processFactory: newProcessFactory(pluginArgs),
 		fs:             filesystem.NewFileSystem(),
 		pluginsByID:    make(map[kindAndName]PluginIdentifier),
 		pluginsByKind:  make(map[PluginKind][]PluginIdentifier),

--- a/pkg/plugin/registry_test.go
+++ b/pkg/plugin/registry_test.go
@@ -32,7 +32,7 @@ func TestNewRegistry(t *testing.T) {
 	logLevel := logrus.InfoLevel
 	dir := "/plugins"
 
-	r := NewRegistry(dir, logger, logLevel).(*registry)
+	r := NewRegistry(dir, []string{}, logger, logLevel).(*registry)
 	assert.Equal(t, dir, r.dir)
 	assert.Equal(t, logger, r.logger)
 	assert.Equal(t, logLevel, r.logLevel)
@@ -107,7 +107,7 @@ func TestReadPluginsDir(t *testing.T) {
 	logLevel := logrus.InfoLevel
 	dir := "/plugins"
 
-	r := NewRegistry(dir, logger, logLevel).(*registry)
+	r := NewRegistry(dir, []string{}, logger, logLevel).(*registry)
 	r.fs = test.NewFakeFileSystem().
 		WithFileAndMode("/plugins/executable1", []byte("plugin1"), 0755).
 		WithFileAndMode("/plugins/nonexecutable2", []byte("plugin2"), 0644).

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,10 +36,14 @@ type ResticRestoreAction struct {
 	initContainerImage string
 }
 
-func NewResticRestoreAction(logger logrus.FieldLogger) *ResticRestoreAction {
+func NewResticRestoreAction(logger logrus.FieldLogger, initContainerImageName string) *ResticRestoreAction {
+	if initContainerImageName == "" {
+		initContainerImageName = initContainerImage()
+	}
+
 	return &ResticRestoreAction{
 		logger:             logger,
-		initContainerImage: initContainerImage(),
+		initContainerImage: initContainerImageName,
 	}
 }
 
@@ -60,7 +64,7 @@ func (a *ResticRestoreAction) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (a *ResticRestoreAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
-	a.logger.Info("Executing ResticRestoreAction")
+	a.logger.Infof("Executing ResticRestoreAction using image %q", a.initContainerImage)
 	defer a.logger.Info("Done executing ResticRestoreAction")
 
 	var pod corev1.Pod


### PR DESCRIPTION
This is an attempt to address #638. I [also](https://github.com/heptio/velero/issues/638#issuecomment-437639874) did not find it straightforward to pass the image from a velero server argument to the plugin command. So, I *tried* to keep changes to a minimum and to just get something working but I'm sure this could be improved. I'd be happy to continue to refine this PR but would love to get some feedback before spending too much time on it. I'd really just like to help get a fix for this so that we can use an official velero build in our on-prem, air gapped environment.
