### PR TITLE
Gracefully handle failed API groups from the discovery API

### DIFF
--- a/changelogs/unreleased/1293-fabito
+++ b/changelogs/unreleased/1293-fabito
@@ -1,0 +1,1 @@
+gracefully handle failed API groups from the discovery API

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -51,9 +51,7 @@ type Helper interface {
 	APIGroups() []metav1.APIGroup
 }
 
-// DiscoveryInterface exposes functions for Kubernetes discovery
-// API.
-type ServerResourcesInterface interface {
+type serverResourcesInterface interface {
 	ServerPreferredResources() ([]*metav1.APIResourceList, error)
 }
 
@@ -147,7 +145,7 @@ func (h *helper) Refresh() error {
 	return nil
 }
 
-func refreshServerPreferredResources(discoveryClient ServerResourcesInterface, logger logrus.FieldLogger) ([]*metav1.APIResourceList, error) {
+func refreshServerPreferredResources(discoveryClient serverResourcesInterface, logger logrus.FieldLogger) ([]*metav1.APIResourceList, error) {
 	preferredResources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		if discoveryErr, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -109,7 +109,11 @@ func (h *helper) Refresh() error {
 
 	preferredResources, err := h.discoveryClient.ServerPreferredResources()
 	if err != nil {
-		return errors.WithStack(err)
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			h.logger.Warnf("Failed to discover some groups: %v", err.(*discovery.ErrGroupDiscoveryFailed).Groups)
+		} else {
+			return errors.WithStack(err)
+		}
 	}
 
 	h.resources = discovery.FilteredBy(

--- a/pkg/discovery/helper_test.go
+++ b/pkg/discovery/helper_test.go
@@ -19,6 +19,9 @@ package discovery
 import (
 	"testing"
 
+	"github.com/heptio/velero/pkg/util/logging"
+	velerotest "github.com/heptio/velero/pkg/util/test"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -139,4 +142,12 @@ func TestFilteringByVerbs(t *testing.T) {
 			assert.Equal(t, test.expected, out)
 		})
 	}
+}
+
+func TestRefreshServerPreferredResources(t *testing.T) {
+	t.Run("One failed group", func(t *testing.T) {
+		resources, err := refreshServerPreferredResources(velerotest.NewFakeServerResourcesInterface(), logging.DefaultLogger(logrus.DebugLevel))
+		assert.NotNil(t, err)
+		assert.NotNil(t, resources)
+	})
 }

--- a/pkg/discovery/helper_test.go
+++ b/pkg/discovery/helper_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package discovery
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/heptio/velero/pkg/util/logging"
 	velerotest "github.com/heptio/velero/pkg/util/test"
@@ -146,9 +148,51 @@ func TestFilteringByVerbs(t *testing.T) {
 }
 
 func TestRefreshServerPreferredResources(t *testing.T) {
-	t.Run("One failed group", func(t *testing.T) {
-		resources, err := refreshServerPreferredResources(velerotest.NewFakeServerResourcesInterface(), logging.DefaultLogger(logrus.DebugLevel))
-		assert.NotNil(t, err)
-		assert.NotNil(t, resources)
-	})
+	tests := []struct {
+		name         string
+		resourceList []*metav1.APIResourceList
+		failedGroups map[schema.GroupVersion]error
+		returnError  error
+	}{
+		{
+			name: "all groups discovered, no error is returned",
+			resourceList: []*metav1.APIResourceList{
+				{GroupVersion: "groupB/v1"},
+				{GroupVersion: "apps/v1beta1"},
+				{GroupVersion: "extensions/v1beta1"},
+			},
+		},
+		{
+			name: "failed to discover some groups, no error is returned",
+			resourceList: []*metav1.APIResourceList{
+				{GroupVersion: "groupB/v1"},
+				{GroupVersion: "apps/v1beta1"},
+				{GroupVersion: "extensions/v1beta1"},
+			},
+			failedGroups: map[schema.GroupVersion]error{
+				{Group: "groupA", Version: "v1"}: errors.New("Fake error"),
+				{Group: "groupC", Version: "v2"}: errors.New("Fake error"),
+			},
+		},
+		{
+			name:        "non ErrGroupDiscoveryFailed error, returns error",
+			returnError: errors.New("Generic error"),
+		},
+	}
+
+	for _, test := range tests {
+		fakeServer := velerotest.NewFakeServerResourcesInterface(test.resourceList, test.failedGroups, test.returnError)
+		t.Run(test.name, func(t *testing.T) {
+			resources, err := refreshServerPreferredResources(fakeServer, logging.DefaultLogger(logrus.DebugLevel))
+			if test.returnError != nil {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.returnError, err)
+			}
+
+			assert.Equal(t, test.resourceList, resources)
+		})
+	}
+
 }

--- a/pkg/discovery/helper_test.go
+++ b/pkg/discovery/helper_test.go
@@ -19,11 +19,12 @@ package discovery
 import (
 	"testing"
 
-	"github.com/heptio/velero/pkg/util/logging"
-	velerotest "github.com/heptio/velero/pkg/util/test"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/heptio/velero/pkg/util/logging"
+	velerotest "github.com/heptio/velero/pkg/util/test"
 )
 
 func TestSortResources(t *testing.T) {

--- a/pkg/util/test/fake_discovery_helper.go
+++ b/pkg/util/test/fake_discovery_helper.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 )
 
 type FakeDiscoveryHelper struct {
@@ -122,4 +123,31 @@ func (dh *FakeDiscoveryHelper) ResourceFor(input schema.GroupVersionResource) (s
 
 func (dh *FakeDiscoveryHelper) APIGroups() []metav1.APIGroup {
 	return dh.APIGroupsList
+}
+
+type FakeServerResourcesInterface struct {
+}
+
+func (di *FakeServerResourcesInterface) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+
+	resourceList := []*metav1.APIResourceList{
+		{GroupVersion: "groupB/v1"},
+		{GroupVersion: "apps/v1beta1"},
+		{GroupVersion: "extensions/v1beta1"},
+	}
+
+	failedGroups := make(map[schema.GroupVersion]error)
+	groupVersion := schema.GroupVersion{
+		Group:   "groupA",
+		Version: "v1",
+	}
+
+	failedGroups[groupVersion] = errors.New("Fake error")
+
+	return resourceList, &discovery.ErrGroupDiscoveryFailed{Groups: failedGroups}
+}
+
+func NewFakeServerResourcesInterface() *FakeServerResourcesInterface {
+	helper := &FakeServerResourcesInterface{}
+	return helper
 }

--- a/pkg/util/test/fake_discovery_helper.go
+++ b/pkg/util/test/fake_discovery_helper.go
@@ -126,28 +126,26 @@ func (dh *FakeDiscoveryHelper) APIGroups() []metav1.APIGroup {
 }
 
 type FakeServerResourcesInterface struct {
+	ResourceList []*metav1.APIResourceList
+	FailedGroups map[schema.GroupVersion]error
+	ReturnError  error
 }
 
 func (di *FakeServerResourcesInterface) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-
-	resourceList := []*metav1.APIResourceList{
-		{GroupVersion: "groupB/v1"},
-		{GroupVersion: "apps/v1beta1"},
-		{GroupVersion: "extensions/v1beta1"},
+	if di.ReturnError != nil {
+		return di.ResourceList, di.ReturnError
 	}
-
-	failedGroups := make(map[schema.GroupVersion]error)
-	groupVersion := schema.GroupVersion{
-		Group:   "groupA",
-		Version: "v1",
+	if di.FailedGroups == nil || len(di.FailedGroups) == 0 {
+		return di.ResourceList, nil
 	}
-
-	failedGroups[groupVersion] = errors.New("Fake error")
-
-	return resourceList, &discovery.ErrGroupDiscoveryFailed{Groups: failedGroups}
+	return di.ResourceList, &discovery.ErrGroupDiscoveryFailed{Groups: di.FailedGroups}
 }
 
-func NewFakeServerResourcesInterface() *FakeServerResourcesInterface {
-	helper := &FakeServerResourcesInterface{}
+func NewFakeServerResourcesInterface(resourceList []*metav1.APIResourceList, failedGroups map[schema.GroupVersion]error, returnError error) *FakeServerResourcesInterface {
+	helper := &FakeServerResourcesInterface{
+		ResourceList: resourceList,
+		FailedGroups: failedGroups,
+		ReturnError:  returnError,
+	}
 	return helper
 }


### PR DESCRIPTION
Fixes #1283 
Fixes #1241 

It improves discovery helper's error handling when `ErrGroupDiscoveryFailed` is returned by `discoveryClient.ServerPreferredResources()`. It now logs the details about the missing groups and continue the execution flow with the partial results.

I'd like to know how would you unit test this change. 

```go
type helper struct {
	discoveryClient discovery.DiscoveryInterface
	logger          logrus.FieldLogger

	// lock guards mapper, resources and resourcesMap
	lock         sync.RWMutex
	mapper       meta.RESTMapper
	resources    []*metav1.APIResourceList
	resourcesMap map[schema.GroupVersionResource]metav1.APIResource
	apiGroups    []metav1.APIGroup
}

Is it difficult to mock `discovery.DiscoveryInterface` and `meta.RESTMapper` ?
```


Signed-off-by: fabito <fuechi@ciandt.com>