### PR TITLE
log error locations from plugin logger and don't overwrite in client

### DIFF
--- a/changelogs/unreleased/1301-skriss
+++ b/changelogs/unreleased/1301-skriss
@@ -1,0 +1,1 @@
+log error locations from plugin logger, and don't overwrite them in the client logger if they exist already

--- a/pkg/plugin/framework/logger.go
+++ b/pkg/plugin/framework/logger.go
@@ -50,6 +50,9 @@ func newLogger() *logrus.Logger {
 	// server logger that the location has been set within a hook.
 	logger.Hooks.Add((&logging.LogLocationHook{}).WithLoggerName("plugin"))
 
+	// make sure we attempt to record the error location
+	logger.Hooks.Add(&logging.ErrorLocationHook{})
+
 	// this hook adjusts the string representation of WarnLevel to "warn"
 	// rather than "warning" to make it parseable by go-plugin within the
 	// Velero server code

--- a/pkg/plugin/framework/logger_test.go
+++ b/pkg/plugin/framework/logger_test.go
@@ -37,6 +37,7 @@ func TestNewLogger(t *testing.T) {
 
 	expectedHooks := []logrus.Hook{
 		(&logging.LogLocationHook{}).WithLoggerName("plugin"),
+		&logging.ErrorLocationHook{},
 		&logging.HcLogLevelHook{},
 	}
 

--- a/pkg/util/logging/error_location_hook.go
+++ b/pkg/util/logging/error_location_hook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,6 +45,17 @@ func (h *ErrorLocationHook) Fire(entry *logrus.Entry) error {
 	)
 
 	if errObj, exists = entry.Data[logrus.ErrorKey]; !exists {
+		return nil
+	}
+
+	if _, ok := entry.Data[errorFileField]; ok {
+		// If there is already an error file field, preserve it instead of overwriting it. This field will already exist if
+		// the log message occurred in the server half of a plugin.
+		return nil
+	}
+	if _, ok := entry.Data[errorFunctionField]; ok {
+		// If there is already an error function field, preserve it instead of overwriting it. This field will already exist if
+		// the log message occurred in the server half of a plugin.
 		return nil
 	}
 

--- a/pkg/util/logging/error_location_hook_test.go
+++ b/pkg/util/logging/error_location_hook_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,6 +56,19 @@ func TestFire(t *testing.T) {
 				logrus.ErrorKey:    pkgerrs.New("a pkg/errors error"),
 				errorFileField:     "",
 				errorFunctionField: "TestFire",
+			},
+		},
+		{
+			name: "already have error file and function fields",
+			preEntryFields: map[string]interface{}{
+				logrus.ErrorKey:    pkgerrs.New("a pkg/errors error"),
+				errorFileField:     "some_file.go:123",
+				errorFunctionField: "SomeFunction",
+			},
+			expectedEntryFields: map[string]interface{}{
+				logrus.ErrorKey:    pkgerrs.New("a pkg/errors error"),
+				errorFileField:     "some_file.go:123",
+				errorFunctionField: "SomeFunction",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Add the "error location" hook to the server-side plugin logger, so that if a plugin author logs an error from within their plugin, the location of that error is included in the log statement as fields. Also update the hook to not overwrite this data if it already exists as fields on the entry, so that log entries coming from a plugin server don't get overwritten on the client.

Pulled from #1119.