### PR TITLE
update plugins to work with updated go-plugin

### DIFF
--- a/pkg/plugin/framework/backup_item_action.go
+++ b/pkg/plugin/framework/backup_item_action.go
@@ -35,12 +35,12 @@ type BackupItemActionPlugin struct {
 var _ plugin.GRPCPlugin = &BackupItemActionPlugin{}
 
 // GRPCClient returns a clientDispenser for BackupItemAction gRPC clients.
-func (p *BackupItemActionPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+func (p *BackupItemActionPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newBackupItemActionGRPCClient), nil
 }
 
 // GRPCServer registers a BackupItemAction gRPC server.
-func (p *BackupItemActionPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+func (p *BackupItemActionPlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
 	proto.RegisterBackupItemActionServer(server, &BackupItemActionGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/backup_item_action.go
+++ b/pkg/plugin/framework/backup_item_action.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"github.com/hashicorp/go-plugin"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	proto "github.com/heptio/velero/pkg/plugin/generated"
@@ -31,13 +32,15 @@ type BackupItemActionPlugin struct {
 	*pluginBase
 }
 
+var _ plugin.GRPCPlugin = &BackupItemActionPlugin{}
+
 // GRPCClient returns a clientDispenser for BackupItemAction gRPC clients.
-func (p *BackupItemActionPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return newClientDispenser(p.clientLogger, c, newBackupItemActionGRPCClient), nil
+func (p *BackupItemActionPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+	return newClientDispenser(p.clientLogger, clientConn, newBackupItemActionGRPCClient), nil
 }
 
 // GRPCServer registers a BackupItemAction gRPC server.
-func (p *BackupItemActionPlugin) GRPCServer(s *grpc.Server) error {
-	proto.RegisterBackupItemActionServer(s, &BackupItemActionGRPCServer{mux: p.serverMux})
+func (p *BackupItemActionPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+	proto.RegisterBackupItemActionServer(server, &BackupItemActionGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/backup_item_action.go
+++ b/pkg/plugin/framework/backup_item_action.go
@@ -32,8 +32,6 @@ type BackupItemActionPlugin struct {
 	*pluginBase
 }
 
-var _ plugin.GRPCPlugin = &BackupItemActionPlugin{}
-
 // GRPCClient returns a clientDispenser for BackupItemAction gRPC clients.
 func (p *BackupItemActionPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newBackupItemActionGRPCClient), nil

--- a/pkg/plugin/framework/block_store.go
+++ b/pkg/plugin/framework/block_store.go
@@ -32,8 +32,6 @@ type BlockStorePlugin struct {
 	*pluginBase
 }
 
-var _ plugin.GRPCPlugin = &BlockStorePlugin{}
-
 // GRPCClient returns a BlockStore gRPC client.
 func (p *BlockStorePlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newBlockStoreGRPCClient), nil

--- a/pkg/plugin/framework/block_store.go
+++ b/pkg/plugin/framework/block_store.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"github.com/hashicorp/go-plugin"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	proto "github.com/heptio/velero/pkg/plugin/generated"
@@ -31,13 +32,15 @@ type BlockStorePlugin struct {
 	*pluginBase
 }
 
+var _ plugin.GRPCPlugin = &BlockStorePlugin{}
+
 // GRPCClient returns a BlockStore gRPC client.
-func (p *BlockStorePlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return newClientDispenser(p.clientLogger, c, newBlockStoreGRPCClient), nil
+func (p *BlockStorePlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+	return newClientDispenser(p.clientLogger, clientConn, newBlockStoreGRPCClient), nil
 }
 
 // GRPCServer registers a BlockStore gRPC server.
-func (p *BlockStorePlugin) GRPCServer(s *grpc.Server) error {
-	proto.RegisterBlockStoreServer(s, &BlockStoreGRPCServer{mux: p.serverMux})
+func (p *BlockStorePlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+	proto.RegisterBlockStoreServer(server, &BlockStoreGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/block_store.go
+++ b/pkg/plugin/framework/block_store.go
@@ -35,12 +35,12 @@ type BlockStorePlugin struct {
 var _ plugin.GRPCPlugin = &BlockStorePlugin{}
 
 // GRPCClient returns a BlockStore gRPC client.
-func (p *BlockStorePlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+func (p *BlockStorePlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newBlockStoreGRPCClient), nil
 }
 
 // GRPCServer registers a BlockStore gRPC server.
-func (p *BlockStorePlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+func (p *BlockStorePlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
 	proto.RegisterBlockStoreServer(server, &BlockStoreGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/object_store.go
+++ b/pkg/plugin/framework/object_store.go
@@ -35,13 +35,13 @@ type ObjectStorePlugin struct {
 var _ plugin.GRPCPlugin = &ObjectStorePlugin{}
 
 // GRPCClient returns an ObjectStore gRPC client.
-func (p *ObjectStorePlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+func (p *ObjectStorePlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newObjectStoreGRPCClient), nil
 
 }
 
 // GRPCServer registers an ObjectStore gRPC server.
-func (p *ObjectStorePlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+func (p *ObjectStorePlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
 	proto.RegisterObjectStoreServer(server, &ObjectStoreGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/object_store.go
+++ b/pkg/plugin/framework/object_store.go
@@ -32,8 +32,6 @@ type ObjectStorePlugin struct {
 	*pluginBase
 }
 
-var _ plugin.GRPCPlugin = &ObjectStorePlugin{}
-
 // GRPCClient returns an ObjectStore gRPC client.
 func (p *ObjectStorePlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newObjectStoreGRPCClient), nil

--- a/pkg/plugin/framework/object_store.go
+++ b/pkg/plugin/framework/object_store.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"github.com/hashicorp/go-plugin"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	proto "github.com/heptio/velero/pkg/plugin/generated"
@@ -31,14 +32,16 @@ type ObjectStorePlugin struct {
 	*pluginBase
 }
 
+var _ plugin.GRPCPlugin = &ObjectStorePlugin{}
+
 // GRPCClient returns an ObjectStore gRPC client.
-func (p *ObjectStorePlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return newClientDispenser(p.clientLogger, c, newObjectStoreGRPCClient), nil
+func (p *ObjectStorePlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+	return newClientDispenser(p.clientLogger, clientConn, newObjectStoreGRPCClient), nil
 
 }
 
 // GRPCServer registers an ObjectStore gRPC server.
-func (p *ObjectStorePlugin) GRPCServer(s *grpc.Server) error {
-	proto.RegisterObjectStoreServer(s, &ObjectStoreGRPCServer{mux: p.serverMux})
+func (p *ObjectStorePlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+	proto.RegisterObjectStoreServer(server, &ObjectStoreGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/plugin_lister.go
+++ b/pkg/plugin/framework/plugin_lister.go
@@ -58,6 +58,8 @@ type PluginListerPlugin struct {
 	impl PluginLister
 }
 
+var _ plugin.GRPCPlugin = &PluginListerPlugin{}
+
 // NewPluginListerPlugin creates a new PluginListerPlugin with impl as the server-side implementation.
 func NewPluginListerPlugin(impl PluginLister) *PluginListerPlugin {
 	return &PluginListerPlugin{impl: impl}
@@ -68,8 +70,8 @@ func NewPluginListerPlugin(impl PluginLister) *PluginListerPlugin {
 //////////////////////////////////////////////////////////////////////////////
 
 // GRPCClient returns a PluginLister gRPC client.
-func (p *PluginListerPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &PluginListerGRPCClient{grpcClient: proto.NewPluginListerClient(c)}, nil
+func (p *PluginListerPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+	return &PluginListerGRPCClient{grpcClient: proto.NewPluginListerClient(clientConn)}, nil
 }
 
 // PluginListerGRPCClient implements PluginLister and uses a gRPC client to make calls to the plugin server.
@@ -106,8 +108,8 @@ func (c *PluginListerGRPCClient) ListPlugins() ([]PluginIdentifier, error) {
 //////////////////////////////////////////////////////////////////////////////
 
 // GRPCServer registers a PluginLister gRPC server.
-func (p *PluginListerPlugin) GRPCServer(s *grpc.Server) error {
-	proto.RegisterPluginListerServer(s, &PluginListerGRPCServer{impl: p.impl})
+func (p *PluginListerPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+	proto.RegisterPluginListerServer(server, &PluginListerGRPCServer{impl: p.impl})
 	return nil
 }
 

--- a/pkg/plugin/framework/plugin_lister.go
+++ b/pkg/plugin/framework/plugin_lister.go
@@ -58,8 +58,6 @@ type PluginListerPlugin struct {
 	impl PluginLister
 }
 
-var _ plugin.GRPCPlugin = &PluginListerPlugin{}
-
 // NewPluginListerPlugin creates a new PluginListerPlugin with impl as the server-side implementation.
 func NewPluginListerPlugin(impl PluginLister) *PluginListerPlugin {
 	return &PluginListerPlugin{impl: impl}

--- a/pkg/plugin/framework/plugin_lister.go
+++ b/pkg/plugin/framework/plugin_lister.go
@@ -70,7 +70,7 @@ func NewPluginListerPlugin(impl PluginLister) *PluginListerPlugin {
 //////////////////////////////////////////////////////////////////////////////
 
 // GRPCClient returns a PluginLister gRPC client.
-func (p *PluginListerPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+func (p *PluginListerPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return &PluginListerGRPCClient{grpcClient: proto.NewPluginListerClient(clientConn)}, nil
 }
 
@@ -108,7 +108,7 @@ func (c *PluginListerGRPCClient) ListPlugins() ([]PluginIdentifier, error) {
 //////////////////////////////////////////////////////////////////////////////
 
 // GRPCServer registers a PluginLister gRPC server.
-func (p *PluginListerPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+func (p *PluginListerPlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
 	proto.RegisterPluginListerServer(server, &PluginListerGRPCServer{impl: p.impl})
 	return nil
 }

--- a/pkg/plugin/framework/plugin_types_test.go
+++ b/pkg/plugin/framework/plugin_types_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginImplementationsAreGRPCPlugins(t *testing.T) {
+	pluginImpls := []interface{}{
+		new(BlockStorePlugin),
+		new(BackupItemActionPlugin),
+		new(ObjectStorePlugin),
+		new(PluginListerPlugin),
+		new(RestoreItemActionPlugin),
+	}
+
+	for _, impl := range pluginImpls {
+		_, ok := impl.(plugin.GRPCPlugin)
+		assert.True(t, ok, "plugin implementation %T does not implement the go-plugin.GRPCPlugin interface", impl)
+	}
+}

--- a/pkg/plugin/framework/restore_item_action.go
+++ b/pkg/plugin/framework/restore_item_action.go
@@ -32,8 +32,6 @@ type RestoreItemActionPlugin struct {
 	*pluginBase
 }
 
-var _ plugin.GRPCPlugin = &RestoreItemActionPlugin{}
-
 // GRPCClient returns a RestoreItemAction gRPC client.
 func (p *RestoreItemActionPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newRestoreItemActionGRPCClient), nil

--- a/pkg/plugin/framework/restore_item_action.go
+++ b/pkg/plugin/framework/restore_item_action.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"github.com/hashicorp/go-plugin"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	proto "github.com/heptio/velero/pkg/plugin/generated"
@@ -31,13 +32,15 @@ type RestoreItemActionPlugin struct {
 	*pluginBase
 }
 
+var _ plugin.GRPCPlugin = &RestoreItemActionPlugin{}
+
 // GRPCClient returns a RestoreItemAction gRPC client.
-func (p *RestoreItemActionPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return newClientDispenser(p.clientLogger, c, newRestoreItemActionGRPCClient), nil
+func (p *RestoreItemActionPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+	return newClientDispenser(p.clientLogger, clientConn, newRestoreItemActionGRPCClient), nil
 }
 
 // GRPCServer registers a RestoreItemAction gRPC server.
-func (p *RestoreItemActionPlugin) GRPCServer(s *grpc.Server) error {
-	proto.RegisterRestoreItemActionServer(s, &RestoreItemActionGRPCServer{mux: p.serverMux})
+func (p *RestoreItemActionPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+	proto.RegisterRestoreItemActionServer(server, &RestoreItemActionGRPCServer{mux: p.serverMux})
 	return nil
 }

--- a/pkg/plugin/framework/restore_item_action.go
+++ b/pkg/plugin/framework/restore_item_action.go
@@ -35,12 +35,12 @@ type RestoreItemActionPlugin struct {
 var _ plugin.GRPCPlugin = &RestoreItemActionPlugin{}
 
 // GRPCClient returns a RestoreItemAction gRPC client.
-func (p *RestoreItemActionPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
+func (p *RestoreItemActionPlugin) GRPCClient(_ context.Context, _ *plugin.GRPCBroker, clientConn *grpc.ClientConn) (interface{}, error) {
 	return newClientDispenser(p.clientLogger, clientConn, newRestoreItemActionGRPCClient), nil
 }
 
 // GRPCServer registers a RestoreItemAction gRPC server.
-func (p *RestoreItemActionPlugin) GRPCServer(broker *plugin.GRPCBroker, server *grpc.Server) error {
+func (p *RestoreItemActionPlugin) GRPCServer(_ *plugin.GRPCBroker, server *grpc.Server) error {
 	proto.RegisterRestoreItemActionServer(server, &RestoreItemActionGRPCServer{mux: p.serverMux})
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Turns out #1303 introduced some runtime breaking changes.  the `GRPCPlugin` interface exported by go-plugin changed -- added context and broker fields.  Unfortunately, it wasn't a compile-time error due to how the types work.  I updated our implementations and added type checks for the future.

cc @carlisia 
