### PR TITLE
Explicitly set encrypt on EC2 CreateVolume

### DIFF
--- a/changelogs/unreleased/1316-mstump
+++ b/changelogs/unreleased/1316-mstump
@@ -1,0 +1,1 @@
+Fix for #1312, use describe to determine if AWS EBS snapshot is encrypted and explicitly pass that value in EC2 CreateVolume call.

--- a/pkg/cloudprovider/aws/block_store.go
+++ b/pkg/cloudprovider/aws/block_store.go
@@ -102,6 +102,7 @@ func (b *BlockStore) CreateVolumeFromSnapshot(snapshotID, volumeType, volumeAZ s
 		SnapshotId:       &snapshotID,
 		AvailabilityZone: &volumeAZ,
 		VolumeType:       &volumeType,
+		Encrypted:        snapRes.Snapshots[0].Encrypted,
 		TagSpecifications: []*ec2.TagSpecification{
 			{
 				ResourceType: aws.String(ec2.ResourceTypeVolume),


### PR DESCRIPTION
use describe to determine if snapshot is encrypted and pass that in EC2 call. Fixes #1312