### PR TITLE
don't wrap io.EOF errors during gRPC streaming

### DIFF
--- a/pkg/plugin/framework/object_store_client.go
+++ b/pkg/plugin/framework/object_store_client.go
@@ -112,6 +112,12 @@ func (c *ObjectStoreGRPCClient) GetObject(bucket, key string) (io.ReadCloser, er
 
 	receive := func() ([]byte, error) {
 		data, err := stream.Recv()
+		if err == io.EOF {
+			// we need to return io.EOF errors unwrapped so that
+			// calling code sees them as io.EOF and knows to stop
+			// reading.
+			return nil, err
+		}
 		if err != nil {
 			return nil, fromGRPCError(err)
 		}

--- a/pkg/plugin/framework/object_store_server.go
+++ b/pkg/plugin/framework/object_store_server.go
@@ -101,6 +101,12 @@ func (s *ObjectStoreGRPCServer) PutObject(stream proto.ObjectStore_PutObjectServ
 		}
 
 		data, err := stream.Recv()
+		if err == io.EOF {
+			// we need to return io.EOF errors unwrapped so that
+			// calling code sees them as io.EOF and knows to stop
+			// reading.
+			return nil, err
+		}
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes the error we've been seeing.