### PR TITLE
Fixes logger configuration for restore plugins

### DIFF
--- a/changelogs/unreleased/1329-sseago
+++ b/changelogs/unreleased/1329-sseago
@@ -1,0 +1,1 @@
+Fixes logger configuration for restore plugins


### PR DESCRIPTION
Fixes #1328 

In restoreController.runRestore, the logger is replaced with a new
io.MultiWriter-based logger. Currently this is done after initializing
the pluginManager, which means the restore plugin logs are being lost.

For backup, newPluginManager is called after the MultiWriter setup,
so log messages from plugins are written to the log as expected.

Untangling this is complicated, because the pluginManager is used for
several actions in restoreController.processRestore before calling
runRestore.

This commit combines restoreController.processRestore and
restoreController.runRestore into one function, with logger reconfiguration
moved above the call to newPluginManager. This is further complicated
by the different return situations in the original two functions
and an attempt to make the result of calling processRestore as close
as possible to what was happening before. A more elegant solution
is probably possible with a more thorough redesign of these functions.

Signed-off-by: Scott Seago <sseago@redhat.com>