### PR TITLE
improve handling of custom S3 URLs

### DIFF
--- a/changelogs/unreleased/1331-skriss
+++ b/changelogs/unreleased/1331-skriss
@@ -1,0 +1,1 @@
+Improve error message around invalid S3 URLs, and gracefully handle trailing backslashes.

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -141,7 +141,7 @@ func newAWSConfig(url, region string, forcePathStyle bool) (*aws.Config, error) 
 
 	if url != "" {
 		if !IsValidS3URLScheme(url) {
-			return nil, errors.Errorf("Invalid s3 url: %s", url)
+			return nil, errors.Errorf("Invalid s3 url %s, URL must be valid according to https://golang.org/pkg/net/url/#Parse and start with http:// or https://", url)
 		}
 
 		awsConfig = awsConfig.WithEndpointResolver(

--- a/pkg/restic/config.go
+++ b/pkg/restic/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ func getRepoPrefix(location *velerov1api.BackupStorageLocation) string {
 			url = fmt.Sprintf("s3-%s.amazonaws.com", region)
 		}
 
-		return fmt.Sprintf("s3:%s/%s", url, bucketAndPrefix)
+		return fmt.Sprintf("s3:%s/%s", strings.TrimSuffix(url, "/"), bucketAndPrefix)
 	case AzureBackend:
 		provider = "azure"
 	case GCPBackend:

--- a/pkg/restic/config_test.go
+++ b/pkg/restic/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -89,6 +89,22 @@ func TestGetRepoIdentifier(t *testing.T) {
 		},
 	}
 	assert.Equal(t, "s3:alternate-url/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+
+	backupLocation = &velerov1api.BackupStorageLocation{
+		Spec: velerov1api.BackupStorageLocationSpec{
+			Provider: "aws",
+			Config: map[string]string{
+				"s3Url": "alternate-url-with-trailing-slash/",
+			},
+			StorageType: velerov1api.StorageType{
+				ObjectStorage: &velerov1api.ObjectStorageLocation{
+					Bucket: "bucket",
+					Prefix: "prefix",
+				},
+			},
+		},
+	}
+	assert.Equal(t, "s3:alternate-url-with-trailing-slash/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

- if a custom S3 URL is invalid, explain what's valid in the error message
- be forgiving if the URL has a trailing slash when setting up the restic repo location