### PR TITLE
Export plugin functionality

### DIFF
--- a/pkg/plugin/framework/backup_item_action.go
+++ b/pkg/plugin/framework/backup_item_action.go
@@ -29,7 +29,7 @@ import (
 // interface.
 type BackupItemActionPlugin struct {
 	plugin.NetRPCUnsupportedPlugin
-	*pluginBase
+	*PluginBase
 }
 
 // GRPCClient returns a clientDispenser for BackupItemAction gRPC clients.

--- a/pkg/plugin/framework/backup_item_action_client.go
+++ b/pkg/plugin/framework/backup_item_action_client.go
@@ -34,7 +34,7 @@ import (
 // NewBackupItemActionPlugin constructs a BackupItemActionPlugin.
 func NewBackupItemActionPlugin(options ...PluginOption) *BackupItemActionPlugin {
 	return &BackupItemActionPlugin{
-		pluginBase: newPluginBase(options...),
+		PluginBase: NewPluginBase(options...),
 	}
 }
 

--- a/pkg/plugin/framework/object_store.go
+++ b/pkg/plugin/framework/object_store.go
@@ -29,7 +29,7 @@ import (
 // interface.
 type ObjectStorePlugin struct {
 	plugin.NetRPCUnsupportedPlugin
-	*pluginBase
+	*PluginBase
 }
 
 // GRPCClient returns an ObjectStore gRPC client.

--- a/pkg/plugin/framework/object_store_client.go
+++ b/pkg/plugin/framework/object_store_client.go
@@ -32,7 +32,7 @@ const byteChunkSize = 16384
 // NewObjectStorePlugin construct an ObjectStorePlugin.
 func NewObjectStorePlugin(options ...PluginOption) *ObjectStorePlugin {
 	return &ObjectStorePlugin{
-		pluginBase: newPluginBase(options...),
+		PluginBase: NewPluginBase(options...),
 	}
 }
 

--- a/pkg/plugin/framework/plugin_base.go
+++ b/pkg/plugin/framework/plugin_base.go
@@ -20,29 +20,29 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type pluginBase struct {
+type PluginBase struct {
 	clientLogger logrus.FieldLogger
 	*serverMux
 }
 
-func newPluginBase(options ...PluginOption) *pluginBase {
-	base := new(pluginBase)
+func NewPluginBase(options ...PluginOption) *PluginBase {
+	base := new(PluginBase)
 	for _, option := range options {
 		option(base)
 	}
 	return base
 }
 
-type PluginOption func(base *pluginBase)
+type PluginOption func(base *PluginBase)
 
 func ClientLogger(logger logrus.FieldLogger) PluginOption {
-	return func(base *pluginBase) {
+	return func(base *PluginBase) {
 		base.clientLogger = logger
 	}
 }
 
 func serverLogger(logger logrus.FieldLogger) PluginOption {
-	return func(base *pluginBase) {
+	return func(base *PluginBase) {
 		base.serverMux = newServerMux(logger)
 	}
 }

--- a/pkg/plugin/framework/plugin_base_test.go
+++ b/pkg/plugin/framework/plugin_base_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestClientLogger(t *testing.T) {
-	base := &pluginBase{}
+	base := &PluginBase{}
 	logger := test.NewLogger()
 	f := ClientLogger(logger)
 	f(base)
@@ -32,7 +32,7 @@ func TestClientLogger(t *testing.T) {
 }
 
 func TestServerLogger(t *testing.T) {
-	base := &pluginBase{}
+	base := &PluginBase{}
 	logger := test.NewLogger()
 	f := serverLogger(logger)
 	f(base)

--- a/pkg/plugin/framework/restore_item_action.go
+++ b/pkg/plugin/framework/restore_item_action.go
@@ -29,7 +29,7 @@ import (
 // interface.
 type RestoreItemActionPlugin struct {
 	plugin.NetRPCUnsupportedPlugin
-	*pluginBase
+	*PluginBase
 }
 
 // GRPCClient returns a RestoreItemAction gRPC client.

--- a/pkg/plugin/framework/restore_item_action_client.go
+++ b/pkg/plugin/framework/restore_item_action_client.go
@@ -34,7 +34,7 @@ var _ velero.RestoreItemAction = &RestoreItemActionGRPCClient{}
 // NewRestoreItemActionPlugin constructs a RestoreItemActionPlugin.
 func NewRestoreItemActionPlugin(options ...PluginOption) *RestoreItemActionPlugin {
 	return &RestoreItemActionPlugin{
-		pluginBase: newPluginBase(options...),
+		PluginBase: NewPluginBase(options...),
 	}
 }
 

--- a/pkg/plugin/framework/volume_snapshotter.go
+++ b/pkg/plugin/framework/volume_snapshotter.go
@@ -29,7 +29,7 @@ import (
 // interface.
 type VolumeSnapshotterPlugin struct {
 	plugin.NetRPCUnsupportedPlugin
-	*pluginBase
+	*PluginBase
 }
 
 // GRPCClient returns a VolumeSnapshotter gRPC client.

--- a/pkg/plugin/framework/volume_snapshotter_client.go
+++ b/pkg/plugin/framework/volume_snapshotter_client.go
@@ -31,7 +31,7 @@ import (
 // NewVolumeSnapshotterPlugin constructs a VolumeSnapshotterPlugin.
 func NewVolumeSnapshotterPlugin(options ...PluginOption) *VolumeSnapshotterPlugin {
 	return &VolumeSnapshotterPlugin{
-		pluginBase: newPluginBase(options...),
+		PluginBase: NewPluginBase(options...),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Carlisia <carlisiac@vmware.com>

Turns out plugin authors need these. Ex:

```
func newBackupPlugin(options ...veleroplugin.PluginOption) *veleroplugin.BackupItemActionPlugin {
	return &veleroplugin.BackupItemActionPlugin{
		PluginBase: veleroplugin.NewPluginBase(options...),
	}
}
```