### PR TITLE
Added example for NooBaa as S3 backend

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,8 @@ This directory contains sample YAML config files for running Velero on each core
 
 * `minio/`: Used in the [Quickstart][1] to set up [Minio][0], a local S3-compatible object storage service. It provides a convenient way to test Velero without tying you to a specific cloud provider.
 
+* `noobaa/`: Contains manifests to make use of NooBaa's S3 storage.
+
 * `aws/`, `azure/`, `gcp/`, `ibm/`: Contains manifests specific to the given cloud provider's setup.
 
 [0]: https://github.com/minio/minio

--- a/examples/noobaa/00-noobaa-creds.yaml
+++ b/examples/noobaa/00-noobaa-creds.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: velero
+  name: cloud-credentials
+  labels:
+    component: noobaa
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id = <NOOBAA_ACCESS_KEY>
+    aws_secret_access_key = <NOOBAA_SECRET_KEY>

--- a/examples/noobaa/05-backupstoragelocation.yaml
+++ b/examples/noobaa/05-backupstoragelocation.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+spec:
+  provider: aws
+  objectStorage:
+    bucket: velero
+  config:
+    region: noobaa
+    s3ForcePathStyle: "true"
+    s3Url: http://s3.noobaa.svc.cluster.local

--- a/examples/noobaa/20-deployment.yaml
+++ b/examples/noobaa/20-deployment.yaml
@@ -1,0 +1,63 @@
+# Copyright 2017 the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  namespace: velero
+  name: velero
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: velero
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8085"
+        prometheus.io/path: "/metrics"
+    spec:
+      restartPolicy: Always
+      serviceAccountName: velero
+      containers:
+        - name: velero
+          image: gcr.io/heptio-images/velero:v0.11.0
+          ports:
+            - name: metrics
+              containerPort: 8085
+          command:
+            - /velero
+          args:
+            - server
+          volumeMounts:
+            - name: cloud-credentials
+              mountPath: /credentials
+            - name: plugins
+              mountPath: /plugins
+            - name: scratch
+              mountPath: /scratch
+          env:
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /credentials/cloud
+            - name: VELERO_SCRATCH_DIR
+              value: /scratch
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: cloud-credentials
+        - name: plugins
+          emptyDir: {}
+        - name: scratch
+          emptyDir: {}


### PR DESCRIPTION
This PR adds example yaml for using an S3 volume as the Velero backupstoragelocation.