### PR TITLE
always allow 'bucket' as a config key for object stores

### DIFF
--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -64,7 +64,7 @@ func isValidSignatureVersion(signatureVersion string) bool {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config,
+	if err := cloudprovider.ValidateObjectStoreConfigKeys(config,
 		regionKey,
 		s3URLKey,
 		publicURLKey,

--- a/pkg/cloudprovider/aws/volume_snapshotter.go
+++ b/pkg/cloudprovider/aws/volume_snapshotter.go
@@ -66,7 +66,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config, regionKey); err != nil {
+	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, regionKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/azure/object_store.go
+++ b/pkg/cloudprovider/azure/object_store.go
@@ -101,7 +101,7 @@ func mapLookup(data map[string]string) func(string) string {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config, resourceGroupConfigKey, storageAccountConfigKey); err != nil {
+	if err := cloudprovider.ValidateObjectStoreConfigKeys(config, resourceGroupConfigKey, storageAccountConfigKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/azure/volume_snapshotter.go
+++ b/pkg/cloudprovider/azure/volume_snapshotter.go
@@ -72,7 +72,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config, resourceGroupConfigKey, apiTimeoutConfigKey); err != nil {
+	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, resourceGroupConfigKey, apiTimeoutConfigKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/config.go
+++ b/pkg/cloudprovider/config.go
@@ -21,7 +21,22 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func ValidateConfigKeys(config map[string]string, validKeys ...string) error {
+// ValidateObjectStoreConfigKeys ensures that an object store's config
+// is valid by making sure each `config` key is in the `validKeys` list.
+// The special key "bucket" is always considered valid.
+func ValidateObjectStoreConfigKeys(config map[string]string, validKeys ...string) error {
+	// `bucket` is automatically added to all object store config by
+	// velero, so add it as a valid key.
+	return validateConfigKeys(config, append(validKeys, "bucket")...)
+}
+
+// ValidateVolumeSnapshotterConfigKeys ensures that a volume snapshotter's
+// config is valid by making sure each `config` key is in the `validKeys` list.
+func ValidateVolumeSnapshotterConfigKeys(config map[string]string, validKeys ...string) error {
+	return validateConfigKeys(config, validKeys...)
+}
+
+func validateConfigKeys(config map[string]string, validKeys ...string) error {
 	validKeysSet := sets.NewString(validKeys...)
 
 	var invalidKeys []string

--- a/pkg/cloudprovider/config_test.go
+++ b/pkg/cloudprovider/config_test.go
@@ -23,12 +23,15 @@ import (
 )
 
 func TestValidateConfigKeys(t *testing.T) {
-	assert.NoError(t, ValidateConfigKeys(nil))
-	assert.NoError(t, ValidateConfigKeys(map[string]string{}))
-	assert.NoError(t, ValidateConfigKeys(map[string]string{"foo": "bar"}, "foo"))
-	assert.NoError(t, ValidateConfigKeys(map[string]string{"foo": "bar", "bar": "baz"}, "foo", "bar"))
+	assert.NoError(t, validateConfigKeys(nil))
+	assert.NoError(t, validateConfigKeys(map[string]string{}))
+	assert.NoError(t, validateConfigKeys(map[string]string{"foo": "bar"}, "foo"))
+	assert.NoError(t, validateConfigKeys(map[string]string{"foo": "bar", "bar": "baz"}, "foo", "bar"))
 
-	assert.Error(t, ValidateConfigKeys(map[string]string{"foo": "bar"}))
-	assert.Error(t, ValidateConfigKeys(map[string]string{"foo": "bar"}, "Foo"))
-	assert.Error(t, ValidateConfigKeys(map[string]string{"foo": "bar", "boo": ""}, "foo"))
+	assert.Error(t, validateConfigKeys(map[string]string{"foo": "bar"}))
+	assert.Error(t, validateConfigKeys(map[string]string{"foo": "bar"}, "Foo"))
+	assert.Error(t, validateConfigKeys(map[string]string{"foo": "bar", "boo": ""}, "foo"))
+
+	assert.NoError(t, ValidateObjectStoreConfigKeys(map[string]string{"bucket": "foo"}))
+	assert.Error(t, ValidateVolumeSnapshotterConfigKeys(map[string]string{"bucket": "foo"}))
 }

--- a/pkg/cloudprovider/gcp/object_store.go
+++ b/pkg/cloudprovider/gcp/object_store.go
@@ -62,7 +62,7 @@ func NewObjectStore(logger logrus.FieldLogger) *ObjectStore {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config); err != nil {
+	if err := cloudprovider.ValidateObjectStoreConfigKeys(config); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/gcp/volume_snapshotter.go
+++ b/pkg/cloudprovider/gcp/volume_snapshotter.go
@@ -53,7 +53,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateConfigKeys(config); err != nil {
+	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1345 

`bucket` is always added to the `config` map by Velero for object stores, so don't error on it. Note that `region` is in fact an invalid key for GCP object stores, so that's a valid error.