### PR TITLE
Set default backup TTL

### DIFF
--- a/changelogs/unreleased/1352-vorar
+++ b/changelogs/unreleased/1352-vorar
@@ -1,0 +1,1 @@
+set default TTL for backups

--- a/docs/api-types/backup.md
+++ b/docs/api-types/backup.md
@@ -66,7 +66,9 @@ spec:
   volumeSnapshotLocations:
     - aws-primary
     - gcp-primary
-  # The amount of time before this backup is eligible for garbage collection.
+  # The amount of time before this backup is eligible for garbage collection. If not specified, 
+  # a default value of 30 days will be used. The default can be configured on the velero server
+  # by passing the flag --default-backup-ttl. 
   ttl: 24h0m0s
   # Actions to perform at different times during a backup. The only hook currently supported is
   # executing a command in a container in a pod using the pod exec API. Optional.


### PR DESCRIPTION
Set default backup TTL to 30 days when TTL
is not provided in the backup yaml configuration.

Updates #138

Signed-off-by: Rohan Vora <vorar@vmware.com>