### PR TITLE
instantiate plugin manager with per-restore logger so plugin logs are captured

### DIFF
--- a/changelogs/unreleased/1358-skriss
+++ b/changelogs/unreleased/1358-skriss
@@ -1,0 +1,1 @@
+instantiate the plugin manager with the per-restore logger so plugin logs are captured in the per-restore log

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -150,7 +150,7 @@ func TestFetchBackupInfo(t *testing.T) {
 	}
 }
 
-func TestProcessRestoreSkips(t *testing.T) {
+func TestProcessQueueItemSkips(t *testing.T) {
 	tests := []struct {
 		name        string
 		restoreKey  string
@@ -212,14 +212,14 @@ func TestProcessRestoreSkips(t *testing.T) {
 				sharedInformers.Velero().V1().Restores().Informer().GetStore().Add(test.restore)
 			}
 
-			err := c.processRestore(test.restoreKey)
+			err := c.processQueueItem(test.restoreKey)
 
 			assert.Equal(t, test.expectError, err != nil)
 		})
 	}
 }
 
-func TestProcessRestore(t *testing.T) {
+func TestProcessQueueItem(t *testing.T) {
 	tests := []struct {
 		name                            string
 		restoreKey                      string
@@ -524,7 +524,7 @@ func TestProcessRestore(t *testing.T) {
 				pluginManager.On("CleanupClients")
 			}
 
-			err = c.processRestore(key)
+			err = c.processQueueItem(key)
 
 			assert.Equal(t, test.expectedErr, err != nil, "got error %v", err)
 			actions := client.Actions()
@@ -716,7 +716,6 @@ func TestValidateAndComplete(t *testing.T) {
 			assert.Equal(t, tc.expectedErrs, tc.restore.Status.ValidationErrors)
 		})
 	}
-
 }
 
 func TestvalidateAndCompleteWhenScheduleNameSpecified(t *testing.T) {


### PR DESCRIPTION
Fixes #1328
Replaces #1329 

I extracted the per-restore log into its own simple struct which makes fixing this a little bit easier, without having to combine the two methods mentioned in #1329. I think this is a little bit cleaner for now. Definitely want to further revisit this code (along with all of `pkg/restore`) post-v1.0.

cc @nrb @carlisia 