### PR TITLE
Prepend velero.io to non-namespaced names

### DIFF
--- a/changelogs/unreleased/1366-nrb
+++ b/changelogs/unreleased/1366-nrb
@@ -1,0 +1,1 @@
+Support non-namespaced names for built-in plugins

--- a/pkg/plugin/clientmgmt/manager.go
+++ b/pkg/plugin/clientmgmt/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clientmgmt
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -124,6 +125,10 @@ func (m *manager) getRestartableProcess(kind framework.PluginKind, name string) 
 
 // GetObjectStore returns a restartableObjectStore for name.
 func (m *manager) GetObjectStore(name string) (velero.ObjectStore, error) {
+	// Backwards compatibility with non-namespaced, built-in plugins.
+	if !strings.Contains(name, "/") {
+		name = "velero.io/" + name
+	}
 	restartableProcess, err := m.getRestartableProcess(framework.PluginKindObjectStore, name)
 	if err != nil {
 		return nil, err
@@ -136,6 +141,10 @@ func (m *manager) GetObjectStore(name string) (velero.ObjectStore, error) {
 
 // GetVolumeSnapshotter returns a restartableVolumeSnapshotter for name.
 func (m *manager) GetVolumeSnapshotter(name string) (velero.VolumeSnapshotter, error) {
+	// Backwards compatibility with non-namespaced, built-in plugins.
+	if !strings.Contains(name, "/") {
+		name = "velero.io/" + name
+	}
 	restartableProcess, err := m.getRestartableProcess(framework.PluginKindVolumeSnapshotter, name)
 	if err != nil {
 		return nil, err
@@ -168,6 +177,10 @@ func (m *manager) GetBackupItemActions() ([]velero.BackupItemAction, error) {
 
 // GetBackupItemAction returns a restartableBackupItemAction for name.
 func (m *manager) GetBackupItemAction(name string) (velero.BackupItemAction, error) {
+	// Backwards compatibility with non-namespaced, built-in plugins.
+	if !strings.Contains(name, "/") {
+		name = "velero.io/" + name
+	}
 	restartableProcess, err := m.getRestartableProcess(framework.PluginKindBackupItemAction, name)
 	if err != nil {
 		return nil, err
@@ -199,6 +212,10 @@ func (m *manager) GetRestoreItemActions() ([]velero.RestoreItemAction, error) {
 
 // GetRestoreItemAction returns a restartableRestoreItemAction for name.
 func (m *manager) GetRestoreItemAction(name string) (velero.RestoreItemAction, error) {
+	// Backwards compatibility with non-namespaced, built-in plugins.
+	if !strings.Contains(name, "/") {
+		name = "velero.io/" + name
+	}
 	restartableProcess, err := m.getRestartableProcess(framework.PluginKindRestoreItemAction, name)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/clientmgmt/manager_test.go
+++ b/pkg/plugin/clientmgmt/manager_test.go
@@ -176,7 +176,7 @@ func TestCleanupClients(t *testing.T) {
 func TestGetObjectStore(t *testing.T) {
 	getPluginTest(t,
 		framework.PluginKindObjectStore,
-		"aws",
+		"velero.io/aws",
 		func(m Manager, name string) (interface{}, error) {
 			return m.GetObjectStore(name)
 		},
@@ -193,7 +193,7 @@ func TestGetObjectStore(t *testing.T) {
 func TestGetVolumeSnapshotter(t *testing.T) {
 	getPluginTest(t,
 		framework.PluginKindVolumeSnapshotter,
-		"aws",
+		"velero.io/aws",
 		func(m Manager, name string) (interface{}, error) {
 			return m.GetVolumeSnapshotter(name)
 		},
@@ -210,7 +210,7 @@ func TestGetVolumeSnapshotter(t *testing.T) {
 func TestGetBackupItemAction(t *testing.T) {
 	getPluginTest(t,
 		framework.PluginKindBackupItemAction,
-		"pod",
+		"velero.io/pod",
 		func(m Manager, name string) (interface{}, error) {
 			return m.GetBackupItemAction(name)
 		},
@@ -227,7 +227,7 @@ func TestGetBackupItemAction(t *testing.T) {
 func TestGetRestoreItemAction(t *testing.T) {
 	getPluginTest(t,
 		framework.PluginKindRestoreItemAction,
-		"pod",
+		"velero.io/pod",
 		func(m Manager, name string) (interface{}, error) {
 			return m.GetRestoreItemAction(name)
 		},
@@ -305,13 +305,13 @@ func TestGetBackupItemActions(t *testing.T) {
 		},
 		{
 			name:                       "Error getting restartable process",
-			names:                      []string{"a", "b", "c"},
+			names:                      []string{"velero.io/a", "velero.io/b", "velero.io/c"},
 			newRestartableProcessError: errors.Errorf("newRestartableProcess"),
 			expectedError:              "newRestartableProcess",
 		},
 		{
 			name:  "Happy path",
-			names: []string{"a", "b", "c"},
+			names: []string{"velero.io/a", "velero.io/b", "velero.io/c"},
 		},
 	}
 	for _, tc := range tests {
@@ -397,13 +397,13 @@ func TestGetRestoreItemActions(t *testing.T) {
 		},
 		{
 			name:                       "Error getting restartable process",
-			names:                      []string{"a", "b", "c"},
+			names:                      []string{"velero.io/a", "velero.io/b", "velero.io/c"},
 			newRestartableProcessError: errors.Errorf("newRestartableProcess"),
 			expectedError:              "newRestartableProcess",
 		},
 		{
 			name:  "Happy path",
-			names: []string{"a", "b", "c"},
+			names: []string{"velero.io/a", "velero.io/b", "velero.io/c"},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Prior to 1.0, user-provided values such as cloud provider names didn't
need to be namespaced. This change allows those values to continue
working without the user editing the fields manually.

Fixes #1363

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>