### PR TITLE
Restic repository management fixes

### DIFF
--- a/changelogs/unreleased/1367-skriss
+++ b/changelogs/unreleased/1367-skriss
@@ -1,0 +1,1 @@
+restic repo ensurer: return error if new repository does not become ready within a minute, and fix channel closing/deletion

--- a/pkg/controller/restic_repository_controller.go
+++ b/pkg/controller/restic_repository_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ func NewResticRepositoryController(
 		},
 	)
 
-	c.resyncPeriod = 30 * time.Minute
+	c.resyncPeriod = 5 * time.Minute
 	c.resyncFunc = c.enqueueAllRepositories
 
 	return c

--- a/pkg/restic/repository_ensurer.go
+++ b/pkg/restic/repository_ensurer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ func newRepositoryEnsurer(repoInformer velerov1informers.ResticRepositoryInforme
 					key := repoLabels(newObj.Spec.VolumeNamespace, newObj.Spec.BackupStorageLocation).String()
 					readyChan, ok := r.readyChans[key]
 					if !ok {
-						log.Errorf("No ready channel found for repository %s/%s", newObj.Namespace, newObj.Name)
+						log.Debugf("No ready channel found for repository %s/%s", newObj.Namespace, newObj.Name)
 						return
 					}
 

--- a/pkg/restic/repository_ensurer.go
+++ b/pkg/restic/repository_ensurer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -171,8 +172,10 @@ func (r *repositoryEnsurer) EnsureRepo(ctx context.Context, namespace, volumeNam
 	}
 
 	select {
-	// TODO it doesn't really make sense to wait for the full pod volume operation timeout
-	// here - repos should become ready quickly if they don't already exist.
+	// repositories should become either ready or not ready quickly if they're
+	// newly created.
+	case <-time.After(time.Minute):
+		return nil, errors.New("timed out waiting for restic repository to become ready")
 	case <-ctx.Done():
 		return nil, errors.New("timed out waiting for restic repository to become ready")
 	case res := <-readyChan:


### PR DESCRIPTION
This does not need to make it into the first alpha, so look at other open PRs first.

Currently if, when creating a new restic repo as part of taking a backup, the repo creation fails, Velero waits for an hour before reporting the failure, because it may "eventually" succeed.  This is a bad UX, though, and if it failed to create the first time, it won't likely succeed the next time without user intervention. So, I changed it so the backup fails fast if the repo creation fails the first time.

I also lowered the resync interval for the restic repo controller, so repos that become "not ready" are retried more often - makes it more likely to get back to a good state after getting into a bad state.

One or two other small fixes in their own commits.

Testing looks good so far, but would like to do some more.

