### PR TITLE
Provide more specific label for velero deployment

### DIFF
--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -84,6 +84,9 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1beta1.Deploy
 
 	}
 
+	containerLabels := labels()
+	containerLabels["deploy"] = "velero"
+
 	deployment := &appsv1beta1.Deployment{
 		ObjectMeta: objectMeta(namespace, "velero"),
 		TypeMeta: metav1.TypeMeta{
@@ -91,9 +94,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1beta1.Deploy
 			APIVersion: appsv1beta1.SchemeGroupVersion.String(),
 		},
 		Spec: appsv1beta1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"deploy": "velero"}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels(),
+					Labels:      containerLabels,
 					Annotations: podAnnotations(),
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Using only the `component: velero` selector caused the restic pods to be
matched, as well, which made things such as `kubectl logs` return too
much information (too many pods),

Feel free to suggest alternative names/values for this label.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>