### PR TITLE
Add PartiallyFailed phase for backups, don't exit on first error

### DIFF
--- a/changelogs/unreleased/1386-skriss
+++ b/changelogs/unreleased/1386-skriss
@@ -1,0 +1,1 @@
+add PartiallyFailed phase for backups, log + continue on errors during backup process

--- a/pkg/apis/velero/v1/backup.go
+++ b/pkg/apis/velero/v1/backup.go
@@ -149,6 +149,10 @@ const (
 	// errors.
 	BackupPhaseCompleted BackupPhase = "Completed"
 
+	// BackupPhasePartiallyFailed means the backup has run to completion
+	// but encountered 1+ errors backing up individual items.
+	BackupPhasePartiallyFailed BackupPhase = "PartiallyFailed"
+
 	// BackupPhaseFailed means the backup ran but encountered an error that
 	// prevented it from completing successfully.
 	BackupPhaseFailed BackupPhase = "Failed"
@@ -191,6 +195,16 @@ type BackupStatus struct {
 	// VolumeSnapshotsCompleted is the total number of successfully
 	// completed volume snapshots for this backup.
 	VolumeSnapshotsCompleted int `json:"volumeSnapshotsCompleted"`
+
+	// Warnings is a count of all warning messages that were generated during
+	// execution of the backup. The actual warnings are in the backup's log
+	// file in object storage.
+	Warnings int `json:"warnings"`
+
+	// Errors is a count of all error messages that were generated during
+	// execution of the backup.  The actual errors are in the backup's log
+	// file in object storage.
+	Errors int `json:"errors"`
 }
 
 // +genclient

--- a/pkg/cmd/cli/backup/logs.go
+++ b/pkg/cmd/cli/backup/logs.go
@@ -50,7 +50,10 @@ func NewLogsCommand(f client.Factory) *cobra.Command {
 				cmd.Exit("Error checking for backup %q: %v", backupName, err)
 			}
 
-			if backup.Status.Phase != v1.BackupPhaseCompleted && backup.Status.Phase != v1.BackupPhaseFailed {
+			switch backup.Status.Phase {
+			case v1.BackupPhaseCompleted, v1.BackupPhasePartiallyFailed, v1.BackupPhaseFailed:
+				// terminal phases, do nothing.
+			default:
 				cmd.Exit("Logs for backup %q are not available until it's finished processing. Please wait "+
 					"until the backup has a phase of Completed or Failed and try again.", backupName)
 			}

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -47,7 +47,13 @@ func DescribeBackup(
 		if phase == "" {
 			phase = velerov1api.BackupPhaseNew
 		}
-		d.Printf("Phase:\t%s\n", phase)
+
+		logsNote := ""
+		if backup.Status.Phase == velerov1api.BackupPhaseFailed || backup.Status.Phase == velerov1api.BackupPhasePartiallyFailed {
+			logsNote = fmt.Sprintf(" (run `velero backup logs %s` for more information)", backup.Name)
+		}
+
+		d.Printf("Phase:\t%s%s\n", phase, logsNote)
 
 		status := backup.Status
 		if len(status.ValidationErrors) > 0 {
@@ -56,6 +62,12 @@ func DescribeBackup(
 			for _, ve := range status.ValidationErrors {
 				d.Printf("\t%s\n", ve)
 			}
+		}
+
+		if status.Phase == velerov1api.BackupPhasePartiallyFailed {
+			d.Println()
+			d.Printf("Errors:\t%d\n", status.Errors)
+			d.Printf("Warnings:\t%d\n", status.Warnings)
 		}
 
 		d.Println()

--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -85,12 +85,20 @@ func printBackup(backup *velerov1api.Backup, w io.Writer, options printers.Print
 		expiration = backup.CreationTimestamp.Add(backup.Spec.TTL.Duration)
 	}
 
-	status := backup.Status.Phase
+	status := string(backup.Status.Phase)
 	if status == "" {
-		status = velerov1api.BackupPhaseNew
+		status = string(velerov1api.BackupPhaseNew)
 	}
 	if backup.DeletionTimestamp != nil && !backup.DeletionTimestamp.Time.IsZero() {
 		status = "Deleting"
+	}
+	if status == string(velerov1api.BackupPhasePartiallyFailed) {
+		if backup.Status.Errors == 1 {
+			status = fmt.Sprintf("%s (1 error)", status)
+		} else {
+			status = fmt.Sprintf("%s (%d errors)", status, backup.Status.Errors)
+		}
+
 	}
 
 	location := backup.Spec.StorageLocation

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,6 +33,7 @@ const (
 	backupTotal                  = "backup_total"
 	backupAttemptTotal           = "backup_attempt_total"
 	backupSuccessTotal           = "backup_success_total"
+	backupPartialFailureTotal    = "backup_partial_failure_total"
 	backupFailureTotal           = "backup_failure_total"
 	backupDurationSeconds        = "backup_duration_seconds"
 	backupDeletionAttemptTotal   = "backup_deletion_attempt_total"
@@ -86,6 +87,14 @@ func NewServerMetrics() *ServerMetrics {
 					Namespace: metricNamespace,
 					Name:      backupSuccessTotal,
 					Help:      "Total number of successful backups",
+				},
+				[]string{scheduleLabel},
+			),
+			backupPartialFailureTotal: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: metricNamespace,
+					Name:      backupPartialFailureTotal,
+					Help:      "Total number of partially failed backups",
 				},
 				[]string{scheduleLabel},
 			),
@@ -230,6 +239,9 @@ func (m *ServerMetrics) InitSchedule(scheduleName string) {
 	if c, ok := m.metrics[backupSuccessTotal].(*prometheus.CounterVec); ok {
 		c.WithLabelValues(scheduleName).Set(0)
 	}
+	if c, ok := m.metrics[backupPartialFailureTotal].(*prometheus.CounterVec); ok {
+		c.WithLabelValues(scheduleName).Set(0)
+	}
 	if c, ok := m.metrics[backupFailureTotal].(*prometheus.CounterVec); ok {
 		c.WithLabelValues(scheduleName).Set(0)
 	}
@@ -292,6 +304,13 @@ func (m *ServerMetrics) RegisterBackupAttempt(backupSchedule string) {
 // RegisterBackupSuccess records a successful completion of a backup.
 func (m *ServerMetrics) RegisterBackupSuccess(backupSchedule string) {
 	if c, ok := m.metrics[backupSuccessTotal].(*prometheus.CounterVec); ok {
+		c.WithLabelValues(backupSchedule).Inc()
+	}
+}
+
+// RegisterBackupPartialFailure records a partially failed backup.
+func (m *ServerMetrics) RegisterBackupPartialFailure(backupSchedule string) {
+	if c, ok := m.metrics[backupPartialFailureTotal].(*prometheus.CounterVec); ok {
 		c.WithLabelValues(backupSchedule).Inc()
 	}
 }

--- a/pkg/util/logging/log_counter_hook.go
+++ b/pkg/util/logging/log_counter_hook.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LogCounterHook is a logrus hook that counts the number of log
+// statements that have been written at each logrus level.
+type LogCounterHook struct {
+	mu     sync.RWMutex
+	counts map[logrus.Level]int
+}
+
+// NewLogCounterHook returns a pointer to an initialized LogCounterHook.
+func NewLogCounterHook() *LogCounterHook {
+	return &LogCounterHook{
+		counts: make(map[logrus.Level]int),
+	}
+}
+
+// Levels returns the logrus levels that the hook should be fired for.
+func (h *LogCounterHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire executes the hook's logic.
+func (h *LogCounterHook) Fire(entry *logrus.Entry) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.counts[entry.Level]++
+
+	return nil
+}
+
+// GetCount returns the number of log statements that have been
+// written at the specific level provided.
+func (h *LogCounterHook) GetCount(level logrus.Level) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.counts[level]
+}


### PR DESCRIPTION
rel #1371

This PR adds the PartiallyFailed phase for backups.  It modifies the backup execution logic so that rather than immediately exiting when the first error is encountered, the error is logged and execution continues. At the end, the number of errors logged is counted, and a >0 result moves the backup to PartiallyFailed.

Still a WIP, but the basic functionality is working. An easy way to see what it looks like is to create a cluster role binding for a cluster role that doesn't exist, to a service account in the namespace you're backing up -- this will create a "partial failure" error.

@nrb @carlisia appreciate any input at this point!