### PR TITLE
bug fix: set discovery helper's logger in constructor

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -72,6 +72,7 @@ var _ Helper = &helper{}
 func NewHelper(discoveryClient discovery.DiscoveryInterface, logger logrus.FieldLogger) (Helper, error) {
 	h := &helper{
 		discoveryClient: discoveryClient,
+		logger:          logger,
 	}
 	if err := h.Refresh(); err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1398 

Whoever gets to this first, pls merge. Don't think we need 2 reviews here.