### PR TITLE
Throw an error on an invalid bucket name

### DIFF
--- a/changelogs/unreleased/140-nrb
+++ b/changelogs/unreleased/140-nrb
@@ -1,0 +1,1 @@
+Disallow bucket names starting with '-'

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -208,6 +209,13 @@ func (o *InstallOptions) Validate(c *cobra.Command, args []string, f client.Fact
 
 	if o.BucketName == "" {
 		return errors.New("--bucket is required")
+	}
+
+	// Our main 3 providers don't support bucket names starting with a dash, and a bucket name starting with one
+	// can indicate that an environment variable was left blank.
+	// This case will help catch that error
+	if strings.HasPrefix(o.BucketName, "-") {
+		return errors.Errorf("Bucket names cannot begin with a dash. Bucket name was: %s", o.BucketName)
 	}
 
 	if o.ProviderName == "" {


### PR DESCRIPTION
This PR is to help troubleshoot some issues arising from unset environment variables when running the `velero install` command. More of a UX/early warning change than major bug fix.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>