### PR TITLE
remove all remaining legacy Ark references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ All authors to the project retain copyright to their work. However, to ensure
 that they are only submitting work that they have rights to, we are requiring
 everyone to acknowledge this by signing their work.
 
-Any copyright notices in this repo should specify the authors as "the Heptio Ark project contributors".
+Any copyright notices in this repo should specify the authors as "the Velero contributors".
 
 To sign your work, just add a line like this at the end of your commit message:
 

--- a/docs/debugging-install.md
+++ b/docs/debugging-install.md
@@ -37,9 +37,9 @@ into the Velero server pod. Ensure the following:
 * The `cloud-credentials` secret is being mounted into the Velero server pod at `/credentials`
 
 #### Using kube2iam
-This means that Ark can't read the content of the S3 bucket. Ensure the following:
-* There is a Trust Policy document allowing the role used by kube2iam to assume Ark's role, as stated in the AWS config documentation.
-* The new Ark role has all the permissions listed in the documentation regarding S3.
+This means that Velero can't read the content of the S3 bucket. Ensure the following:
+* There is a Trust Policy document allowing the role used by kube2iam to assume Velero's role, as stated in the AWS config documentation.
+* The new Velero role has all the permissions listed in the documentation regarding S3.
 
 
 ## Azure

--- a/pkg/apis/velero/v1/restore.go
+++ b/pkg/apis/velero/v1/restore.go
@@ -18,14 +18,14 @@ package v1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// RestoreSpec defines the specification for an Ark restore.
+// RestoreSpec defines the specification for a Velero restore.
 type RestoreSpec struct {
-	// BackupName is the unique name of the Ark backup to restore
+	// BackupName is the unique name of the Velero backup to restore
 	// from.
 	BackupName string `json:"backupName"`
 
-	// ScheduleName is the unique name of the Ark schedule to restore
-	// from. If specified, and BackupName is empty, Ark will restore
+	// ScheduleName is the unique name of the Velero schedule to restore
+	// from. If specified, and BackupName is empty, Velero will restore
 	// from the most recent successful backup created from this schedule.
 	ScheduleName string `json:"scheduleName,omitempty"`
 
@@ -67,7 +67,7 @@ type RestoreSpec struct {
 }
 
 // RestorePhase is a string representation of the lifecycle phase
-// of an Ark restore
+// of a Velero restore
 type RestorePhase string
 
 const (
@@ -95,7 +95,7 @@ const (
 	RestorePhaseFailed RestorePhase = "Failed"
 )
 
-// RestoreStatus captures the current status of an Ark restore
+// RestoreStatus captures the current status of a Velero restore
 type RestoreStatus struct {
 	// Phase is the current state of the Restore
 	Phase RestorePhase `json:"phase"`
@@ -119,8 +119,8 @@ type RestoreStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Restore is an Ark resource that represents the application of
-// resources from an Ark backup to a target Kubernetes cluster.
+// Restore is a Velero resource that represents the application of
+// resources from a Velero backup to a target Kubernetes cluster.
 type Restore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/cmd/cli/client/config/config.go
+++ b/pkg/cmd/cli/client/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Heptio Ark contributors.
+Copyright 2017 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/client/config/get.go
+++ b/pkg/cmd/cli/client/config/get.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Heptio Ark contributors.
+Copyright 2018 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/client/config/set.go
+++ b/pkg/cmd/cli/client/config/set.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Heptio Ark contributors.
+Copyright 2018 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -58,18 +58,15 @@ var nonRestorableResources = []string{
 
 	// Don't ever restore backups - if appropriate, they'll be synced in from object storage.
 	// https://github.com/heptio/velero/issues/622
-	"backups.ark.heptio.com",
 	"backups.velero.io",
 
 	// Restores are cluster-specific, and don't have value moving across clusters.
 	// https://github.com/heptio/velero/issues/622
-	"restores.ark.heptio.com",
 	"restores.velero.io",
 
 	// Restic repositories are automatically managed by Velero and will be automatically
 	// created as needed if they don't exist.
 	// https://github.com/heptio/velero/issues/1113
-	"resticrepositories.ark.heptio.com",
 	"resticrepositories.velero.io",
 }
 

--- a/pkg/plugin/velero/restore_item_action.go
+++ b/pkg/plugin/velero/restore_item_action.go
@@ -45,7 +45,7 @@ type RestoreItemActionExecuteInput struct {
 	Item runtime.Unstructured
 	// ItemFromBackup is the item taken from the pristine backed up version of resource.
 	ItemFromBackup runtime.Unstructured
-	// Restore is the representation of the restore resource processed by Ark.
+	// Restore is the representation of the restore resource processed by Velero.
 	Restore *api.Restore
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

I think this removes the last batch of "Ark" refs from the code, apart from docs that explicitly discuss the migration from Heptio Ark to Velero.

@nrb @carlisia 