### PR TITLE
switch to snapshots cmd for checking repo exists

### DIFF
--- a/changelogs/unreleased/1416-skriss
+++ b/changelogs/unreleased/1416-skriss
@@ -1,0 +1,1 @@
+switch from `restic stats` to `restic snapshots` for checking restic repository existence

--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -84,9 +84,9 @@ func InitCommand(repoIdentifier string) *Command {
 	}
 }
 
-func StatsCommand(repoIdentifier string) *Command {
+func SnapshotsCommand(repoIdentifier string) *Command {
 	return &Command{
-		Command:        "stats",
+		Command:        "snapshots",
 		RepoIdentifier: repoIdentifier,
 	}
 }

--- a/pkg/restic/command_factory_test.go
+++ b/pkg/restic/command_factory_test.go
@@ -96,10 +96,10 @@ func TestInitCommand(t *testing.T) {
 	assert.Equal(t, "repo-id", c.RepoIdentifier)
 }
 
-func TestStatsCommand(t *testing.T) {
-	c := StatsCommand("repo-id")
+func TestSnapshotsCommand(t *testing.T) {
+	c := SnapshotsCommand("repo-id")
 
-	assert.Equal(t, "stats", c.Command)
+	assert.Equal(t, "snapshots", c.Command)
 	assert.Equal(t, "repo-id", c.RepoIdentifier)
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

#1171 switched from using `restic check` to `restic stats` for determining if a restic repository existed.  It turns out that `restic stats` is still not the optimal choice, as it can be slow on very large repositories.  

Per https://restic.readthedocs.io/en/stable/075_scripting.html#check-if-a-repository-is-already-initialized, the recommended command to use is `restic snapshots`. This PR makes that switch.  I'm also using the `--last` flag to minimize the amount of data returned from the command, but this is just a small optimization.