### PR TITLE
remove ref to v0.10 from BSL validation error msg

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -444,10 +444,7 @@ func (s *server) validateBackupStorageLocations() error {
 		}
 
 		if err := backupStore.IsValid(); err != nil {
-			invalid = append(invalid, errors.Wrapf(err,
-				"backup store for location %q is invalid (if upgrading from a pre-v0.10 version of Velero, please refer to https://heptio.github.io/velero/v0.10.0/storage-layout-reorg-v0.10 for instructions)",
-				location.Name,
-			).Error())
+			invalid = append(invalid, errors.Wrapf(err, "backup store for location %q is invalid", location.Name).Error())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Minor change to remove pre-1.0 reference from error msg.