### PR TITLE
Separate upload part for the BlockStore

### DIFF
--- a/pkg/backup/resource_backupper.go
+++ b/pkg/backup/resource_backupper.go
@@ -278,6 +278,7 @@ func (rb *defaultResourceBackupper) backupResource(group *metav1.APIResourceList
 		}
 	}
 
+	itemBackupper.uploadItem(log)
 	return nil
 }
 

--- a/pkg/plugin/clientmgmt/restartable_volume_snapshotter.go
+++ b/pkg/plugin/clientmgmt/restartable_volume_snapshotter.go
@@ -159,3 +159,12 @@ func (r *restartableVolumeSnapshotter) DeleteSnapshot(snapshotID string) error {
 	}
 	return delegate.DeleteSnapshot(snapshotID)
 }
+
+// UploadSnapshot restarts the plugin's process if needed, then delegates the call.
+func (r *restartableVolumeSnapshotter) UploadSnapshot(volumeID string, volumeAZ string, tags map[string]string) error {
+	delegate, err := r.getDelegate()
+	if err != nil {
+		return err
+	}
+	return delegate.UploadSnapshot(volumeID, volumeAZ, tags)
+}

--- a/pkg/plugin/velero/volume_snapshotter.go
+++ b/pkg/plugin/velero/volume_snapshotter.go
@@ -50,4 +50,7 @@ type VolumeSnapshotter interface {
 
 	// DeleteSnapshot deletes the specified volume snapshot.
 	DeleteSnapshot(snapshotID string) error
+
+	// UploadSnapshot uploads all the snapshots at the end
+	UploadSnapshot(volumeID, volumeAZ string, tags map[string]string) error
 }


### PR DESCRIPTION
VolumeSnapshotter i.e BlockStore interface should have an extra method,
called as `UploadSnapshot()`. This method should make use of all the tags and
snapshot objects used for `CreateSnapshot()` method. Hence, add a way to store
these information to the `itemBackupper`.

Signed-off-by: Satyam Zode <satyamzode@gmail.com>