### PR TITLE
shortcut expander: use discovery helper's cached resource list

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -105,12 +105,6 @@ func (h *helper) Refresh() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
-	shortcutExpander, err := kcmdutil.NewShortcutExpander(mapper, h.discoveryClient, h.logger)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	h.mapper = shortcutExpander
 
 	preferredResources, err := refreshServerPreferredResources(h.discoveryClient, h.logger)
 	if err != nil {
@@ -123,6 +117,12 @@ func (h *helper) Refresh() error {
 	)
 
 	sortResources(h.resources)
+
+	shortcutExpander, err := kcmdutil.NewShortcutExpander(restmapper.NewDiscoveryRESTMapper(groupResources), h.resources, h.logger)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	h.mapper = shortcutExpander
 
 	h.resourcesMap = make(map[schema.GroupVersionResource]metav1.APIResource)
 	for _, resourceGroup := range h.resources {

--- a/third_party/kubernetes/pkg/kubectl/cmd/util/shortcut_expander.go
+++ b/third_party/kubernetes/pkg/kubectl/cmd/util/shortcut_expander.go
@@ -1,6 +1,8 @@
 /*
 Copyright 2016 The Kubernetes Authors.
 
+Modifications Copyright 2019 the Velero contributors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -17,13 +19,12 @@ limitations under the License.
 package util
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 )
 
 // ResourceShortcuts represents a structure that holds the information how to
@@ -37,17 +38,14 @@ type ResourceShortcuts struct {
 type shortcutExpander struct {
 	RESTMapper meta.RESTMapper
 
-	discoveryClient discovery.DiscoveryInterface
-	logger          logrus.FieldLogger
+	resources []*metav1.APIResourceList
+	logger    logrus.FieldLogger
 }
 
 var _ meta.RESTMapper = &shortcutExpander{}
 
-func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface, logger logrus.FieldLogger) (shortcutExpander, error) {
-	if client == nil {
-		return shortcutExpander{}, errors.New("Please provide discovery client to shortcut expander")
-	}
-	return shortcutExpander{RESTMapper: delegate, discoveryClient: client}, nil
+func NewShortcutExpander(delegate meta.RESTMapper, resources []*metav1.APIResourceList, logger logrus.FieldLogger) (shortcutExpander, error) {
+	return shortcutExpander{RESTMapper: delegate, resources: resources, logger: logger}, nil
 }
 
 func (e shortcutExpander) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
@@ -88,28 +86,24 @@ func (e shortcutExpander) getShortcutMappings() ([]ResourceShortcuts, error) {
 	haveNetpol := false
 
 	res := []ResourceShortcuts{}
-	// get server resources
-	apiResList, err := e.discoveryClient.ServerResources()
-	if err == nil {
-		for _, apiResources := range apiResList {
-			for _, apiRes := range apiResources.APIResources {
-				for _, shortName := range apiRes.ShortNames {
-					gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)
-					if err != nil {
-						e.logger.WithError(err).WithField("groupVersion", apiResources.GroupVersion).Error("Unable to parse groupversion")
-						continue
-					}
-					rs := ResourceShortcuts{
-						ShortForm: schema.GroupResource{Group: gv.Group, Resource: shortName},
-						LongForm:  schema.GroupResource{Group: gv.Group, Resource: apiRes.Name},
-					}
-					res = append(res, rs)
-					if shortName == "svc" {
-						haveSvc = true
-					}
-					if shortName == "netpol" {
-						haveNetpol = true
-					}
+	for _, apiResources := range e.resources {
+		for _, apiRes := range apiResources.APIResources {
+			for _, shortName := range apiRes.ShortNames {
+				gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)
+				if err != nil {
+					e.logger.WithError(err).WithField("groupVersion", apiResources.GroupVersion).Error("Unable to parse groupversion")
+					continue
+				}
+				rs := ResourceShortcuts{
+					ShortForm: schema.GroupResource{Group: gv.Group, Resource: shortName},
+					LongForm:  schema.GroupResource{Group: gv.Group, Resource: apiRes.Name},
+				}
+				res = append(res, rs)
+				if shortName == "svc" {
+					haveSvc = true
+				}
+				if shortName == "netpol" {
+					haveNetpol = true
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1413 
Fixes #1435 
Fixes #1414 

Change the shortcut expander (which expands things like "po" to pods) to use the discovery helper's cached list of API resources, so it doesn't have to call the discovery client every time there's an expansion to do.

Still doing a little bit of testing, but initial basic tests look good functionally, and make a *major* performance impact (a sample restore dropped from 45sec to 2sec, a full-cluster backup dropped from 2+ minutes to 11 seconds).

We should revisit the discovery code a little bit post-1.0 as there have been some upstream changes, but happy with this change for now since it's simple and has a big impact.