### PR TITLE
Add snapshot-location to `velero create` command

### DIFF
--- a/pkg/cmd/cli/create/create.go
+++ b/pkg/cmd/cli/create/create.go
@@ -24,6 +24,7 @@ import (
 	"github.com/heptio/velero/pkg/cmd/cli/backuplocation"
 	"github.com/heptio/velero/pkg/cmd/cli/restore"
 	"github.com/heptio/velero/pkg/cmd/cli/schedule"
+	"github.com/heptio/velero/pkg/cmd/cli/snapshotlocation"
 )
 
 func NewCommand(f client.Factory) *cobra.Command {
@@ -38,6 +39,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 		schedule.NewCreateCommand(f, "schedule"),
 		restore.NewCreateCommand(f, "restore"),
 		backuplocation.NewCreateCommand(f, "backup-location"),
+		snapshotlocation.NewCreateCommand(f, "snapshot-location"),
 	)
 
 	return c


### PR DESCRIPTION
`velero snapshot-location create` existed, but not `velero create
snapshot-location`; update subcommand for parity with backup-location

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>