### PR TITLE
Document that hooks don't execute within a shell

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -7,7 +7,8 @@ Velero currently supports executing commands in containers in pods during a back
 When performing a backup, you can specify one or more commands to execute in a container in a pod
 when that pod is being backed up. The commands can be configured to run *before* any custom action
 processing ("pre" hooks), or after all custom actions have been completed and any additional items
-specified by custom action have been backed up ("post" hooks).
+specified by custom action have been backed up ("post" hooks). Note that hooks are _not_ executed within a shell
+on the containers.
 
 There are two ways to specify hooks: annotations on the pod itself, and in the Backup spec.
 


### PR DESCRIPTION
This came up in Slack, and is per https://github.com/kubernetes/api/blob/master/core/v1/types.go#L4490

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>