### PR TITLE
Don't log error if restic volume is empty

### DIFF
--- a/changelogs/unreleased/1480-carlisia.md
+++ b/changelogs/unreleased/1480-carlisia.md
@@ -1,0 +1,1 @@
+Stop returning an error when a restic volume is empty since it is a valid scenario.

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -254,7 +254,7 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 		r.Status.Phase = velerov1api.PodVolumeBackupPhaseCompleted
 		r.Status.SnapshotID = snapshotID
 		if emptySnapshot {
-			r.Status.Message = "backup completed with an empty volume"
+			r.Status.Message = "volume was empty so no snapshot was taken"
 		}
 	})
 	if err != nil {

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2018, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -228,23 +228,34 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 
 	var stdout, stderr string
 
+	var emptySnapshot bool
 	if stdout, stderr, err = veleroexec.RunCommand(resticCmd.Cmd()); err != nil {
-		log.WithError(errors.WithStack(err)).Errorf("Error running command=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
-		return c.fail(req, fmt.Sprintf("error running restic backup, stderr=%s: %s", stderr, err.Error()), log)
+		if strings.Contains(stderr, "snapshot is empty") {
+			emptySnapshot = true
+		} else {
+			log.WithError(errors.WithStack(err)).Errorf("Error running command=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
+			return c.fail(req, fmt.Sprintf("error running restic backup, stderr=%s: %s", stderr, err.Error()), log)
+		}
 	}
 	log.Debugf("Ran command=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
 
-	snapshotID, err := restic.GetSnapshotID(req.Spec.RepoIdentifier, file, req.Spec.Tags, env)
-	if err != nil {
-		log.WithError(err).Error("Error getting SnapshotID")
-		return c.fail(req, errors.Wrap(err, "error getting snapshot id").Error(), log)
+	var snapshotID string
+	if !emptySnapshot {
+		snapshotID, err = restic.GetSnapshotID(req.Spec.RepoIdentifier, file, req.Spec.Tags, env)
+		if err != nil {
+			log.WithError(err).Error("Error getting SnapshotID")
+			return c.fail(req, errors.Wrap(err, "error getting snapshot id").Error(), log)
+		}
 	}
 
 	// update status to Completed with path & snapshot id
 	req, err = c.patchPodVolumeBackup(req, func(r *velerov1api.PodVolumeBackup) {
 		r.Status.Path = path
-		r.Status.SnapshotID = snapshotID
 		r.Status.Phase = velerov1api.PodVolumeBackupPhaseCompleted
+		r.Status.SnapshotID = snapshotID
+		if emptySnapshot {
+			r.Status.Message = "backup completed with an empty volume"
+		}
 	})
 	if err != nil {
 		log.WithError(err).Error("Error setting phase to Completed")

--- a/pkg/restic/backupper.go
+++ b/pkg/restic/backupper.go
@@ -168,7 +168,7 @@ ForEachVolume:
 		case res := <-resultsChan:
 			switch res.Status.Phase {
 			case velerov1api.PodVolumeBackupPhaseCompleted:
-				if res.Status.SnapshotID == "" {
+				if res.Status.SnapshotID == "" { // when the volume is empty there is no restic snapshot, so best to exclude it
 					delete(volumeSnapshots, res.Spec.Volume)
 					break
 				}

--- a/pkg/restic/backupper.go
+++ b/pkg/restic/backupper.go
@@ -168,6 +168,10 @@ ForEachVolume:
 		case res := <-resultsChan:
 			switch res.Status.Phase {
 			case velerov1api.PodVolumeBackupPhaseCompleted:
+				if res.Status.SnapshotID == "" {
+					delete(volumeSnapshots, res.Spec.Volume)
+					break
+				}
 				volumeSnapshots[res.Spec.Volume] = res.Status.SnapshotID
 			case velerov1api.PodVolumeBackupPhaseFailed:
 				errs = append(errs, errors.Errorf("pod volume backup failed: %s", res.Status.Message))


### PR DESCRIPTION
Fixes #1266.

Couple of notes:

1)
I thought this error would happen here: https://github.com/heptio/velero/blob/ee8f8ca1db5917b631547b5f59e4075caee66b20/pkg/controller/pod_volume_backup_controller.go#L233

But the execution path doesn't go thru there.

2)
I made small mods to some error messages to make them different from one another. Let me know if it's best to leave them as they were.

Signed-off-by: Carlisia <carlisiac@vmware.com>