### PR TITLE
doc(support-matrix): Add OpenEBS to Volume Snapshot Providers

### DIFF
--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -40,6 +40,7 @@ _Some storage providers, like Quobyte, may need a different [signature algorithm
 | [Restic][1]                      | Velero Team        | [Slack][10], [GitHub Issue][11] |
 | [Portworx][6]                    | Portworx        | [Slack][13], [GitHub Issue][14] |
 | [DigitalOcean][7]                | StackPointCloud |                                 |
+| [OpenEBS][18]                     | OpenEBS       | [Slack][19], [GitHub Issue][20] |
 
 ### Adding a new plugin
 
@@ -64,3 +65,6 @@ After you publish your plugin, open a PR that adds your plugin to the appropriat
 [15]: api-types/backupstoragelocation.md#aws
 [16]: http://www.noobaa.com/
 [17]: restic.md
+[18]: https://github.com/openebs/velero-plugin
+[19]: https://openebs-community.slack.com/
+[20]: https://github.com/openebs/velero-plugin/issues


### PR DESCRIPTION
This PR is to add OpenEBS plugin to the list of volume snapshot providers in 'Support matrix' document.

OpenEBS is an open-source, CAS architecture, storage solution. It has Velero plugin to do snapshot, backup/restore of snapshotted data of its CStor volumes, and, compatible with Velero 0.10 and 0.11 versions.
The source code of plugin is available at https://github.com/openebs/velero-plugin.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>