### PR TITLE
    Only run CI when relevant files have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ sudo: required
 services:
   - docker
 
-script: make ci
+script: hack/ci-check.sh

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# If we're doing push build, as opposed to a PR, always run make ci
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    make ci
+    # Exit script early, returning make ci's error
+    exit $?
+fi
+
+# Only run `make ci` if files outside of the site directory changed in the branch
+# In a PR build, $TRAVIS_BRANCH is the destination branch.
+if [[ $(git diff --name-only $TRAVIS_BRANCH | grep --invert-match site/) ]]; then
+  make ci
+else
+  echo "Skipping make ci since nothing outside of site directory changed."
+  exit 0
+fi


### PR DESCRIPTION
 * If nothing was modified under the site directory, don't run a netlify build
 * If nothing outside of the site directory was modified, don't run `make ci`.

 Signed-off-by: Nolan Brubaker <brubakern@vmware.com>