### PR TITLE
allow individual backup storage locations to be read-only

### DIFF
--- a/changelogs/unreleased/1517-skriss
+++ b/changelogs/unreleased/1517-skriss
@@ -1,0 +1,1 @@
+Allow individual backup storage locations to be read-only

--- a/pkg/apis/velero/v1/backup_storage_location.go
+++ b/pkg/apis/velero/v1/backup_storage_location.go
@@ -66,6 +66,10 @@ type BackupStorageLocationSpec struct {
 	Config map[string]string `json:"config"`
 
 	StorageType `json:",inline"`
+
+	// ReadOnly is whether the backup storage location is in read-only mode. If true,
+	// backups cannot be created or deleted in this location.
+	ReadOnly bool `json:"readOnly"`
 }
 
 // BackupStorageLocationPhase is the lifecyle phase of a Velero BackupStorageLocation.

--- a/pkg/apis/velero/v1/backup_storage_location.go
+++ b/pkg/apis/velero/v1/backup_storage_location.go
@@ -67,9 +67,8 @@ type BackupStorageLocationSpec struct {
 
 	StorageType `json:",inline"`
 
-	// ReadOnly is whether the backup storage location is in read-only mode. If true,
-	// backups cannot be created or deleted in this location.
-	ReadOnly bool `json:"readOnly"`
+	// AccessMode defines the permissions for the backup storage location.
+	AccessMode BackupStorageLocationAccessMode `json:"accessMode,omitempty"`
 }
 
 // BackupStorageLocationPhase is the lifecyle phase of a Velero BackupStorageLocation.
@@ -94,10 +93,17 @@ const (
 	BackupStorageLocationAccessModeReadWrite BackupStorageLocationAccessMode = "ReadWrite"
 )
 
+// TODO(2.0): remove the AccessMode field from BackupStorageLocationStatus.
+
 // BackupStorageLocationStatus describes the current status of a Velero BackupStorageLocation.
 type BackupStorageLocationStatus struct {
-	Phase              BackupStorageLocationPhase      `json:"phase,omitempty"`
-	AccessMode         BackupStorageLocationAccessMode `json:"accessMode,omitempty"`
-	LastSyncedRevision types.UID                       `json:"lastSyncedRevision,omitempty"`
-	LastSyncedTime     metav1.Time                     `json:"lastSyncedTime,omitempty"`
+	Phase              BackupStorageLocationPhase `json:"phase,omitempty"`
+	LastSyncedRevision types.UID                  `json:"lastSyncedRevision,omitempty"`
+	LastSyncedTime     metav1.Time                `json:"lastSyncedTime,omitempty"`
+
+	// AccessMode is an unused field.
+	//
+	// Deprecated: there is now an AccessMode field on the Spec and this field
+	// will be removed entirely as of v2.0.
+	AccessMode BackupStorageLocationAccessMode `json:"accessMode,omitempty"`
 }

--- a/pkg/cmd/cli/backuplocation/create.go
+++ b/pkg/cmd/cli/backuplocation/create.go
@@ -59,6 +59,7 @@ type CreateOptions struct {
 	Prefix   string
 	Config   flag.Map
 	Labels   flag.Map
+	ReadOnly bool
 }
 
 func NewCreateOptions() *CreateOptions {
@@ -73,6 +74,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Prefix, "prefix", o.Prefix, "prefix under which all Velero data should be stored within the bucket. Optional.")
 	flags.Var(&o.Config, "config", "configuration key-value pairs")
 	flags.Var(&o.Labels, "labels", "labels to apply to the backup storage location")
+	flags.BoolVar(&o.ReadOnly, "read-only", o.ReadOnly, "whether the backup storage location should be created as read-only.")
 }
 
 func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {
@@ -111,7 +113,8 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 					Prefix: o.Prefix,
 				},
 			},
-			Config: o.Config.Data(),
+			Config:   o.Config.Data(),
+			ReadOnly: o.ReadOnly,
 		},
 	}
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -194,7 +194,7 @@ func NewCommand() *cobra.Command {
 	command.Flags().StringVar(&config.metricsAddress, "metrics-address", config.metricsAddress, "the address to expose prometheus metrics")
 	command.Flags().DurationVar(&config.backupSyncPeriod, "backup-sync-period", config.backupSyncPeriod, "how often to ensure all Velero backups in object storage exist as Backup API objects in the cluster")
 	command.Flags().DurationVar(&config.podVolumeOperationTimeout, "restic-timeout", config.podVolumeOperationTimeout, "how long backups/restores of pod volumes should be allowed to run before timing out")
-	command.Flags().BoolVar(&config.restoreOnly, "restore-only", config.restoreOnly, "run in a mode where only restores are allowed; backups, schedules, and garbage-collection are all disabled")
+	command.Flags().BoolVar(&config.restoreOnly, "restore-only", config.restoreOnly, "run in a mode where only restores are allowed; backups, schedules, and garbage-collection are all disabled. DEPRECATED: this flag will be removed in v2.0. Use read-only backup storage locations instead.")
 	command.Flags().StringSliceVar(&config.disabledControllers, "disable-controllers", config.disabledControllers, fmt.Sprintf("list of controllers to disable on startup. Valid values are %s", strings.Join(disableControllerList, ",")))
 	command.Flags().StringSliceVar(&config.restoreResourcePriorities, "restore-resource-priorities", config.restoreResourcePriorities, "desired order of resource restores; any resource not in the list will be restored alphabetically after the prioritized resources")
 	command.Flags().StringVar(&config.defaultBackupLocation, "default-backup-storage-location", config.defaultBackupLocation, "name of the default backup storage location")

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -629,6 +629,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.sharedInformerFactory.Velero().V1().Backups(),
 			s.sharedInformerFactory.Velero().V1().DeleteBackupRequests(),
 			s.veleroClient.VeleroV1(),
+			s.sharedInformerFactory.Velero().V1().BackupStorageLocations(),
 		)
 
 		return controllerRunInfo{

--- a/pkg/cmd/util/output/backup_storage_location_printer.go
+++ b/pkg/cmd/util/output/backup_storage_location_printer.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	backupStorageLocationColumns = []string{"NAME", "PROVIDER", "BUCKET/PREFIX"}
+	backupStorageLocationColumns = []string{"NAME", "PROVIDER", "BUCKET/PREFIX", "ACCESS MODE"}
 )
 
 func printBackupStorageLocationList(list *v1.BackupStorageLocationList, w io.Writer, options printers.PrintOptions) error {
@@ -52,12 +52,18 @@ func printBackupStorageLocation(location *v1.BackupStorageLocation, w io.Writer,
 		bucketAndPrefix += "/" + location.Spec.ObjectStorage.Prefix
 	}
 
+	accessMode := location.Spec.AccessMode
+	if accessMode == "" {
+		accessMode = v1.BackupStorageLocationAccessModeReadWrite
+	}
+
 	if _, err := fmt.Fprintf(
 		w,
-		"%s\t%s\t%s",
+		"%s\t%s\t%s\t%s",
 		name,
 		location.Spec.Provider,
 		bucketAndPrefix,
+		accessMode,
 	); err != nil {
 		return err
 	}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -319,7 +319,7 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 	} else {
 		request.StorageLocation = storageLocation
 
-		if request.StorageLocation.Spec.ReadOnly {
+		if request.StorageLocation.Spec.AccessMode == velerov1api.BackupStorageLocationAccessModeReadOnly {
 			request.Status.ValidationErrors = append(request.Status.ValidationErrors,
 				fmt.Sprintf("backup can't be created because backup storage location %s is currently in read-only mode", request.StorageLocation.Name))
 		}

--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -318,6 +318,11 @@ func (c *backupController) prepareBackupRequest(backup *velerov1api.Backup) *pkg
 		}
 	} else {
 		request.StorageLocation = storageLocation
+
+		if request.StorageLocation.Spec.ReadOnly {
+			request.Status.ValidationErrors = append(request.Status.ValidationErrors,
+				fmt.Sprintf("backup can't be created because backup storage location %s is currently in read-only mode", request.StorageLocation.Name))
+		}
 	}
 
 	// validate and get the backup's VolumeSnapshotLocations, and store the

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -221,7 +221,7 @@ func (c *backupDeletionController) processRequest(req *v1.DeleteBackupRequest) e
 		return errors.Wrap(err, "error getting backup storage location")
 	}
 
-	if location.Spec.ReadOnly {
+	if location.Spec.AccessMode == v1.BackupStorageLocationAccessModeReadOnly {
 		_, err := c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
 			r.Status.Phase = v1.DeleteBackupRequestPhaseProcessed
 			r.Status.Errors = append(r.Status.Errors, fmt.Sprintf("cannot delete backup because backup storage location %s is currently in read-only mode", location.Name))

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -19,9 +19,10 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,7 @@ import (
 	kubeerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/heptio/velero/pkg/apis/velero/v1"
+	v1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	pkgbackup "github.com/heptio/velero/pkg/backup"
 	velerov1client "github.com/heptio/velero/pkg/generated/clientset/versioned/typed/velero/v1"
 	informers "github.com/heptio/velero/pkg/generated/informers/externalversions/velero/v1"
@@ -192,18 +193,6 @@ func (c *backupDeletionController) processRequest(req *v1.DeleteBackupRequest) e
 		return err
 	}
 
-	// Update status to InProgress and set backup-name label if needed
-	req, err = c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
-		r.Status.Phase = v1.DeleteBackupRequestPhaseInProgress
-
-		if req.Labels[v1.BackupNameLabel] == "" {
-			req.Labels[v1.BackupNameLabel] = label.GetValidName(req.Spec.BackupName)
-		}
-	})
-	if err != nil {
-		return err
-	}
-
 	// Get the backup we're trying to delete
 	backup, err := c.backupClient.Backups(req.Namespace).Get(req.Spec.BackupName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -216,7 +205,40 @@ func (c *backupDeletionController) processRequest(req *v1.DeleteBackupRequest) e
 		return err
 	}
 	if err != nil {
-		return errors.Wrap(err, "error getting Backup")
+		return errors.Wrap(err, "error getting backup")
+	}
+
+	// Don't allow deleting backups in read-only storage locations
+	location, err := c.backupLocationLister.BackupStorageLocations(backup.Namespace).Get(backup.Spec.StorageLocation)
+	if apierrors.IsNotFound(err) {
+		_, err := c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
+			r.Status.Phase = v1.DeleteBackupRequestPhaseProcessed
+			r.Status.Errors = append(r.Status.Errors, fmt.Sprintf("backup storage location %s not found", backup.Spec.StorageLocation))
+		})
+		return err
+	}
+	if err != nil {
+		return errors.Wrap(err, "error getting backup storage location")
+	}
+
+	if location.Spec.ReadOnly {
+		_, err := c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
+			r.Status.Phase = v1.DeleteBackupRequestPhaseProcessed
+			r.Status.Errors = append(r.Status.Errors, fmt.Sprintf("cannot delete backup because backup storage location %s is currently in read-only mode", location.Name))
+		})
+		return err
+	}
+
+	// Update status to InProgress and set backup-name label if needed
+	req, err = c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
+		r.Status.Phase = v1.DeleteBackupRequestPhaseInProgress
+
+		if req.Labels[v1.BackupNameLabel] == "" {
+			req.Labels[v1.BackupNameLabel] = label.GetValidName(req.Spec.BackupName)
+		}
+	})
+	if err != nil {
+		return err
 	}
 
 	// Set backup-uid label if needed
@@ -246,9 +268,9 @@ func (c *backupDeletionController) processRequest(req *v1.DeleteBackupRequest) e
 	pluginManager := c.newPluginManager(log)
 	defer pluginManager.CleanupClients()
 
-	backupStore, backupStoreErr := c.backupStoreForBackup(backup, pluginManager, log)
-	if backupStoreErr != nil {
-		errs = append(errs, backupStoreErr.Error())
+	backupStore, err := c.newBackupStore(location, pluginManager, log)
+	if err != nil {
+		errs = append(errs, err.Error())
 	}
 
 	if backupStore != nil {
@@ -375,19 +397,6 @@ func volumeSnapshotterForSnapshotLocation(
 	return volumeSnapshotter, nil
 }
 
-func (c *backupDeletionController) backupStoreForBackup(backup *v1.Backup, pluginManager clientmgmt.Manager, log logrus.FieldLogger) (persistence.BackupStore, error) {
-	backupLocation, err := c.backupLocationLister.BackupStorageLocations(backup.Namespace).Get(backup.Spec.StorageLocation)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	backupStore, err := c.newBackupStore(backupLocation, pluginManager, log)
-	if err != nil {
-		return nil, err
-	}
-
-	return backupStore, nil
-}
 func (c *backupDeletionController) deleteExistingDeletionRequests(req *v1.DeleteBackupRequest, log logrus.FieldLogger) []error {
 	log.Info("Removing existing deletion requests for backup")
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{

--- a/pkg/controller/gc_controller.go
+++ b/pkg/controller/gc_controller.go
@@ -145,7 +145,7 @@ func (c *gcController) processQueueItem(key string) error {
 		return errors.Wrap(err, "error getting backup storage location")
 	}
 
-	if loc.Spec.ReadOnly {
+	if loc.Spec.AccessMode == velerov1api.BackupStorageLocationAccessModeReadOnly {
 		log.Infof("Backup cannot be garbage-collected because backup storage location %s is currently in read-only mode", loc.Name)
 		return nil
 	}

--- a/pkg/util/test/test_backup_storage_location.go
+++ b/pkg/util/test/test_backup_storage_location.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2017, 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,5 +64,10 @@ func (b *TestBackupStorageLocation) WithObjectStorage(bucketName string) *TestBa
 		b.Spec.StorageType.ObjectStorage = &v1.ObjectStorageLocation{}
 	}
 	b.Spec.ObjectStorage.Bucket = bucketName
+	return b
+}
+
+func (b *TestBackupStorageLocation) WithAccessMode(accessMode v1.BackupStorageLocationAccessMode) *TestBackupStorageLocation {
+	b.Spec.AccessMode = accessMode
 	return b
 }

--- a/site/docs/master/about.md
+++ b/site/docs/master/about.md
@@ -31,7 +31,7 @@ The **restore** operation allows you to restore all of the objects and persisten
 
 The default name of a restore is `<BACKUP NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. You can also specify a custom name. A restored object also includes a label with key `velero.io/restore-name` and value `<RESTORE NAME>`.
 
-You can also run the Velero server in restore-only mode, which disables backup, schedule, and garbage collection functionality during disaster recovery.
+You can also configure backup storage locations in read-only mode, which disables backup creation and deletion for the storage location during disaster recovery. 
 
 ## Backup workflow
 

--- a/site/docs/master/about.md
+++ b/site/docs/master/about.md
@@ -31,7 +31,7 @@ The **restore** operation allows you to restore all of the objects and persisten
 
 The default name of a restore is `<BACKUP NAME>-<TIMESTAMP>`, where `<TIMESTAMP>` is formatted as *YYYYMMDDhhmmss*. You can also specify a custom name. A restored object also includes a label with key `velero.io/restore-name` and value `<RESTORE NAME>`.
 
-You can also configure backup storage locations in read-only mode, which disables backup creation and deletion for the storage location during disaster recovery. 
+By default, backup storage locations are created in read-write mode. However, during a restore, you can configure a backup storage location to be in read-only mode, which disables backup creation and deletion for the storage location. This is useful to ensure that no backups are inadvertently created or deleted during a restore scenario.
 
 ## Backup workflow
 

--- a/site/docs/master/disaster-case.md
+++ b/site/docs/master/disaster-case.md
@@ -1,6 +1,6 @@
 # Disaster recovery
 
-*Using Schedules and Restore-Only Mode*
+*Using Schedules and Read-Only Backup Storage Locations*
 
 If you periodically back up your cluster's resources, you are able to return to a previous state in case of some unexpected mishap, such as a service outage. Doing so with Velero looks like the following:
 
@@ -14,7 +14,14 @@ If you periodically back up your cluster's resources, you are able to return to 
 
 1.  A disaster happens and you need to recreate your resources.
 
-1.  Update the Velero server deployment, adding the argument for the `server` command flag `restore-only` set to `true`. This prevents Backup objects from being created or deleted during your Restore process.
+1.  Update your backup storage location to be in read-only mode. This prevents Backup objects from being created or deleted in the backup storage location during your Restore process:
+
+    ```bash
+    kubectl patch backupstoragelocation <STORAGE LOCATION NAME> \
+        --namespace velero \
+        --type merge \
+        --patch '{"spec":{"accessMode":"ReadOnly"}}'
+    ```
 
 1.  Create a restore with your most recent Velero Backup:
 

--- a/site/docs/master/disaster-case.md
+++ b/site/docs/master/disaster-case.md
@@ -14,7 +14,7 @@ If you periodically back up your cluster's resources, you are able to return to 
 
 1.  A disaster happens and you need to recreate your resources.
 
-1.  Update your backup storage location to be in read-only mode. This prevents Backup objects from being created or deleted in the backup storage location during your Restore process:
+1.  Update your backup storage location to read-only mode (this prevents backup objects from being created or deleted in the backup storage location during the restore process):
 
     ```bash
     kubectl patch backupstoragelocation <STORAGE LOCATION NAME> \
@@ -27,4 +27,13 @@ If you periodically back up your cluster's resources, you are able to return to 
 
     ```
     velero restore create --from-backup <SCHEDULE NAME>-<TIMESTAMP>
+    ```
+
+1. When ready, revert your backup storage location to read-write mode:
+
+   ```bash
+   kubectl patch backupstoragelocation <STORAGE LOCATION NAME> \
+       --namespace velero \
+       --type merge \
+       --patch '{"spec":{"accessMode":"ReadWrite"}}'
     ```

--- a/site/docs/master/faq.md
+++ b/site/docs/master/faq.md
@@ -38,6 +38,7 @@ and not to use prefixes at all.
 
 Related to this, if you need to restore a backup that was created in cluster A into cluster B, you may 
 configure cluster B with a backup storage location that points to cluster A's bucket/prefix. If you do
-this, you should use restore-only mode in cluster B's Velero instance (via the `--restore-only` flag on 
-the `velero server` command specified in your Velero deployment) while it's configured to use cluster A's 
-bucket/prefix. This will ensure no new backups are created, and no existing backups are deleted or overwritten.
+this, you should configure the storage location pointing to cluster A's bucket/prefix in `ReadOnly` mode
+via the `--access-mode=ReadOnly` flag on the `velero backup-location create` command. This will ensure no
+new backups are created from Cluster B in Cluster A's bucket/prefix, and no existing backups are deleted
+or overwritten.

--- a/site/docs/master/migration-case.md
+++ b/site/docs/master/migration-case.md
@@ -12,9 +12,8 @@ Velero can help you port your resources from one cluster to another, as long as 
 
     The default TTL is 30 days (720 hours); you can use the `--ttl` flag to change this as necessary.
 
-1.  *(Cluster 2)* Add the `--restore-only` flag to the server spec in the Velero deployment YAML.
-
-1.  *(Cluster 2)* Make sure that the `BackupStorageLocation` and `VolumeSnapshotLocation` CRDs match the ones from *Cluster 1*, so that your new Velero server instance points to the same bucket.
+1.  *(Cluster 2)* Configure `BackupStorageLocations` and `VolumeSnapshotLocations`, pointing to the locations used by *Cluster 1*, using `velero backup-location create` and `velero snapshot-location create`. Make sure to configure the `BackupStorageLocations` as read-only
+    by using the `--access-mode=ReadOnly` flag for `velero backup-location create`.
 
 1.  *(Cluster 2)* Make sure that the Velero Backup object is created. Velero resources are synchronized with the backup files in cloud storage.
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1514 

TODO:
- [x] test cases
- [x] documentation updates
- [x] add deprecation notice to `--restore-only` flag for `velero server` (should wait until 2.0 to drop, I think)