### PR TITLE
fixes inlining of command in GCP setup docs

### DIFF
--- a/site/docs/master/gcp-config.md
+++ b/site/docs/master/gcp-config.md
@@ -61,6 +61,7 @@ To integrate Velero with GCP, create a Velero-specific [Service Account][15]:
     > If you'll be using Velero to backup multiple clusters with multiple GCS buckets, it may be desirable to create a unique username per cluster rather than the default `velero`.
 
     Then list all accounts and find the `velero` account you just created:
+
     ```bash
     gcloud iam service-accounts list
     ```

--- a/site/docs/v1.0.0/gcp-config.md
+++ b/site/docs/v1.0.0/gcp-config.md
@@ -61,6 +61,7 @@ To integrate Velero with GCP, create a Velero-specific [Service Account][15]:
     > If you'll be using Velero to backup multiple clusters with multiple GCS buckets, it may be desirable to create a unique username per cluster rather than the default `velero`.
 
     Then list all accounts and find the `velero` account you just created:
+
     ```bash
     gcloud iam service-accounts list
     ```


### PR DESCRIPTION
Currently this command gets inlined in the docs site, when it should appear in its own block.

![Screen Shot 2019-06-05 at 16 27 43](https://user-images.githubusercontent.com/1544861/58996878-e060a480-87ae-11e9-9084-3bb802b6661c.png)

Let me know if this is not the right place to make this fix, or if I need to replicate the fix in the other version folders?

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>