### PR TITLE
Support for multiple AWS profiles

### DIFF
--- a/changelogs/unreleased/1548-pranavgaikwad
+++ b/changelogs/unreleased/1548-pranavgaikwad
@@ -1,0 +1,1 @@
+support for multiple AWS profiles

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -82,6 +82,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		kmsKeyIDKey,
 		s3ForcePathStyleKey,
 		signatureVersionKey,
+		credentialProfileKey,
 	); err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/aws/object_store.go
+++ b/pkg/cloudprovider/aws/object_store.go
@@ -36,12 +36,13 @@ import (
 )
 
 const (
-	s3URLKey            = "s3Url"
-	publicURLKey        = "publicUrl"
-	kmsKeyIDKey         = "kmsKeyId"
-	s3ForcePathStyleKey = "s3ForcePathStyle"
-	bucketKey           = "bucket"
-	signatureVersionKey = "signatureVersion"
+	s3URLKey             = "s3Url"
+	publicURLKey         = "publicUrl"
+	kmsKeyIDKey          = "kmsKeyId"
+	s3ForcePathStyleKey  = "s3ForcePathStyle"
+	bucketKey            = "bucket"
+	signatureVersionKey  = "signatureVersion"
+	credentialProfileKey = "profile"
 )
 
 type s3Interface interface {
@@ -92,6 +93,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		kmsKeyID            = config[kmsKeyIDKey]
 		s3ForcePathStyleVal = config[s3ForcePathStyleKey]
 		signatureVersion    = config[signatureVersionKey]
+		credentialProfile   = config[credentialProfileKey]
 
 		// note that bucket is automatically added to the config map
 		// by the server from the ObjectStorageProviderConfig so
@@ -124,7 +126,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		return err
 	}
 
-	serverSession, err := getSession(serverConfig)
+	serverSession, err := getSession(serverConfig, credentialProfile)
 	if err != nil {
 		return err
 	}
@@ -145,7 +147,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return err
 		}
-		publicSession, err := getSession(publicConfig)
+		publicSession, err := getSession(publicConfig, credentialProfile)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloudprovider/aws/volume_snapshotter.go
+++ b/pkg/cloudprovider/aws/volume_snapshotter.go
@@ -68,7 +68,7 @@ func NewVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, regionKey); err != nil {
+	if err := cloudprovider.ValidateVolumeSnapshotterConfigKeys(config, regionKey, credentialProfileKey); err != nil {
 		return err
 	}
 

--- a/pkg/cloudprovider/aws/volume_snapshotter.go
+++ b/pkg/cloudprovider/aws/volume_snapshotter.go
@@ -48,8 +48,10 @@ type VolumeSnapshotter struct {
 	ec2 *ec2.EC2
 }
 
-func getSession(config *aws.Config) (*session.Session, error) {
-	sess, err := session.NewSession(config)
+// takes AWS credential config & a profile to create a new session
+func getSession(config *aws.Config, profile string) (*session.Session, error) {
+	sessionOptions := session.Options{Config: *config, Profile: profile}
+	sess, err := session.NewSessionWithOptions(sessionOptions)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -71,13 +73,14 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	}
 
 	region := config[regionKey]
+	credentialProfile := config[credentialProfileKey]
 	if region == "" {
 		return errors.Errorf("missing %s in aws configuration", regionKey)
 	}
 
 	awsConfig := aws.NewConfig().WithRegion(region)
 
-	sess, err := getSession(awsConfig)
+	sess, err := getSession(awsConfig, credentialProfile)
 	if err != nil {
 		return err
 	}

--- a/site/docs/master/api-types/backupstoragelocation.md
+++ b/site/docs/master/api-types/backupstoragelocation.md
@@ -20,6 +20,7 @@ spec:
     bucket: myBucket
   config:
     region: us-west-2
+    profile: "default"
 ```
 
 ### Parameter Reference
@@ -36,6 +37,7 @@ The configurable parameters are as follows:
 | `objectStorage/prefix` | String | Optional Field | The directory inside a storage bucket where backups are to be uploaded. |
 | `config` | map[string]string<br><br>(See the corresponding [AWS][0], [GCP][1], and [Azure][2]-specific configs or your provider's documentation.) | None (Optional) | Configuration keys/values to be passed to the cloud provider for backup storage. |
 
+
 #### AWS
 
 **(Or other S3-compatible storage)**
@@ -50,6 +52,7 @@ The configurable parameters are as follows:
 | `publicUrl` | string | Empty | *Example*: https://minio.mycluster.com<br><br>If specified, use this instead of `s3Url` when generating download URLs (e.g., for logs). This field is primarily for local storage services like Minio.|
 | `kmsKeyId` | string | Empty | *Example*: "502b409c-4da1-419f-a16e-eif453b3i49f" or "alias/`<KMS-Key-Alias-Name>`"<br><br>Specify an [AWS KMS key][10] id or alias to enable encryption of the backups stored in S3. Only works with AWS S3 and may require explicitly granting key usage rights.|
 | `signatureVersion` | string | `"4"` | Version of the signature algorithm used to create signed URLs that are used by velero cli to download backups or fetch logs. Possible versions are "1" and "4". Usually the default version 4 is correct, but some S3-compatible providers like Quobyte only support version 1.|
+| `profile` | string | "default" | AWS profile within the credential file to use for given store |
 
 #### Azure
 

--- a/site/docs/master/api-types/volumesnapshotlocation.md
+++ b/site/docs/master/api-types/volumesnapshotlocation.md
@@ -20,6 +20,7 @@ spec:
   provider: aws
   config:
     region: us-west-2
+    profile: "default"
 ```
 
 ### Parameter Reference
@@ -40,6 +41,7 @@ The configurable parameters are as follows:
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
+| `profile` | string | "default" | AWS profile within the credential file to use for given store |
 
 #### Azure
 


### PR DESCRIPTION
Currently, velero does not support different credentials for different S3 buckets. The S3 connection established uses `default` profile. AWS SDK supports multiple profiles to be used. This change adds support for multiple profiles by introducing a new config variable in backup storage location definition. When a profile is not set explicitly by the user, AWS SDK automatically selects the `default` profile making this change not break existing configurations.