### PR TITLE
Fixed 404 Link in Blog

### DIFF
--- a/changelogs/unreleased/1522-coonsd
+++ b/changelogs/unreleased/1522-coonsd
@@ -1,0 +1,1 @@
+Added author as a tag on blog post.  Should fix 404 error when trying to follow link as specified in issue #1522.

--- a/site/_posts/2019-05-20-velero-1.0-has-arrived.md
+++ b/site/_posts/2019-05-20-velero-1.0-has-arrived.md
@@ -6,7 +6,7 @@ author_name: Tom Spoonemore
 # author_avatar: https://placehold.it/64x64
 categories: ['velero','release']
 # Tag should match author to drive author pages
-tags: ['Velero Team']
+tags: ['Velero Team', 'Tom Spoonemore']
 ---
 Just three months after the release of Velero 0.11, the community’s momentum continues with the delivery of the landmark version 1.0 release. <!--more--> This significant release improves the installation experience, Helm support, the plugin system, and overall stability. We want to thank the community and the team, and acknowledge all of their hard work and amazing contributions to this major milestone.
 


### PR DESCRIPTION
#1522 : Added the author's name as a tag.  This should fix the broken link.