### PR TITLE
fix panic when processing DeleteBackupRequest objs without labels

### DIFF
--- a/changelogs/unreleased/1556-prydonius
+++ b/changelogs/unreleased/1556-prydonius
@@ -1,0 +1,1 @@
+fix panic when processing DeleteBackupRequest objects without labels

--- a/pkg/controller/backup_deletion_controller.go
+++ b/pkg/controller/backup_deletion_controller.go
@@ -229,6 +229,12 @@ func (c *backupDeletionController) processRequest(req *v1.DeleteBackupRequest) e
 		return err
 	}
 
+	// if the request object has no labels defined, initialise an empty map since
+	// we will be updating labels
+	if req.Labels == nil {
+		req.Labels = map[string]string{}
+	}
+
 	// Update status to InProgress and set backup-name label if needed
 	req, err = c.patchDeleteBackupRequest(req, func(r *v1.DeleteBackupRequest) {
 		r.Status.Phase = v1.DeleteBackupRequestPhaseInProgress

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -460,8 +460,10 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 		}
 		require.NoError(t, td.sharedInformers.Velero().V1().VolumeSnapshotLocations().Informer().GetStore().Add(snapshotLocation))
 
-		// Clear out req labels to make sure the controller adds them
-		td.req.Labels = make(map[string]string)
+		// Clear out req labels to make sure the controller adds them and does not
+		// panic when encountering a nil Labels map
+		// (https://github.com/heptio/velero/issues/1546)
+		td.req.Labels = nil
 
 		td.client.PrependReactor("get", "backups", func(action core.Action) (bool, runtime.Object, error) {
 			return true, backup, nil


### PR DESCRIPTION
This fix initialises an empty map if the request object's Labels map
is nil, allowing the controller to later add and modify labels on the
object.

fixes #1546 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>