### PR TITLE
hide server commands in velero CLI

### DIFF
--- a/changelogs/unreleased/1561-prydonius
+++ b/changelogs/unreleased/1561-prydonius
@@ -1,0 +1,1 @@
+Hides `velero server` and `velero restic server` commands from the list of available commands as these are not intended for use by the velero CLI user.

--- a/pkg/cmd/cli/restic/server.go
+++ b/pkg/cmd/cli/restic/server.go
@@ -46,10 +46,9 @@ func NewServerCommand(f client.Factory) *cobra.Command {
 	logLevelFlag := logging.LogLevelFlag(logrus.InfoLevel)
 
 	command := &cobra.Command{
-		Use:   "server",
-		Short: "Run the velero restic server",
-		Long:  "Run the velero restic server",
-		// hide from list of available commands as this is not used by the CLI user
+		Use:    "server",
+		Short:  "Run the velero restic server",
+		Long:   "Run the velero restic server",
 		Hidden: true,
 		Run: func(c *cobra.Command, args []string) {
 			logLevel := logLevelFlag.Parse()

--- a/pkg/cmd/cli/restic/server.go
+++ b/pkg/cmd/cli/restic/server.go
@@ -49,6 +49,8 @@ func NewServerCommand(f client.Factory) *cobra.Command {
 		Use:   "server",
 		Short: "Run the velero restic server",
 		Long:  "Run the velero restic server",
+		// hide from list of available commands as this is not used by the CLI user
+		Hidden: true,
 		Run: func(c *cobra.Command, args []string) {
 			logLevel := logLevelFlag.Parse()
 			logrus.Infof("Setting log-level to %s", strings.ToUpper(logLevel.String()))

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -150,6 +150,8 @@ func NewCommand() *cobra.Command {
 		Use:   "server",
 		Short: "Run the velero server",
 		Long:  "Run the velero server",
+		// hide from list of available commands as this is not used by the CLI user
+		Hidden: true,
 		Run: func(c *cobra.Command, args []string) {
 			// go-plugin uses log.Println to log when it's waiting for all plugin processes to complete so we need to
 			// set its output to stdout.

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -147,10 +147,9 @@ func NewCommand() *cobra.Command {
 	)
 
 	var command = &cobra.Command{
-		Use:   "server",
-		Short: "Run the velero server",
-		Long:  "Run the velero server",
-		// hide from list of available commands as this is not used by the CLI user
+		Use:    "server",
+		Short:  "Run the velero server",
+		Long:   "Run the velero server",
 		Hidden: true,
 		Run: func(c *cobra.Command, args []string) {
 			// go-plugin uses log.Println to log when it's waiting for all plugin processes to complete so we need to


### PR DESCRIPTION
Hides `velero server` and `velero restic server` commands from the list of available commands as these are not intended for use by the velero CLI user.

fixes #1527 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>