### PR TITLE
Fix test comparison

### DIFF
--- a/pkg/serverstatusrequest/process_test.go
+++ b/pkg/serverstatusrequest/process_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package serverstatusrequest
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -164,11 +165,23 @@ func TestProcess(t *testing.T) {
 				assert.Nil(t, res)
 				assert.True(t, apierrors.IsNotFound(err))
 			} else {
+				sortPluginsByKindAndName(tc.expected.Status.Plugins)
+				sortPluginsByKindAndName(res.Status.Plugins)
+				assert.Equal(t, tc.expected.Status.Plugins, res.Status.Plugins)
 				assert.Equal(t, tc.expected, res)
 				assert.Nil(t, err)
 			}
 		})
 	}
+}
+
+func sortPluginsByKindAndName(plugins []velerov1api.PluginInfo) {
+	sort.Slice(plugins, func(i, j int) bool {
+		if plugins[i].Kind != plugins[j].Kind {
+			return plugins[i].Kind < plugins[j].Kind
+		}
+		return plugins[i].Name < plugins[j].Name
+	})
 }
 
 type fakePluginLister struct {


### PR DESCRIPTION
I think this will fix it (see https://travis-ci.org/heptio/velero/builds/543954241). I cleared the test cache and ran this test a buncha times.

This is making me think though: what if...

1) I moved the `sortPluginsByKindAndName` function to the `process.go` file, used it to build the list of sorted plugins (by name and kind) here: https://github.com/heptio/velero/blob/e183c4b5978ce4f1d68e78acb0343e1eec9f6ee1/pkg/serverstatusrequest/process.go#L110

2) Removed this function (since the list is being built in order): https://github.com/heptio/velero/blob/e183c4b5978ce4f1d68e78acb0343e1eec9f6ee1/pkg/cmd/util/output/plugin_printer.go#L35

3) Used the `process.go/sortPluginsByKindAndName` to sort (only) the test slice.

I think this would work?

Signed-off-by: Carlisia <carlisiac@vmware.com>