### PR TITLE
Discontinue use of excerpt separators in blog posts.

### DIFF
--- a/site/_posts/2019-04-09-Velero-is-an-Open-Source-Tool-to-Back-up-and-Migrate-Kubernetes-Clusters.md
+++ b/site/_posts/2019-04-09-Velero-is-an-Open-Source-Tool-to-Back-up-and-Migrate-Kubernetes-Clusters.md
@@ -1,14 +1,14 @@
 ---
 title: Velero is an Open Source Tool to Back up and Migrate Kubernetes Clusters
 # image: https://placehold.it/200x200
-excerpt_separator: <!--more-->
+excerpt: Velero is an open source tool to safely back up, recover, and migrate Kubernetes clusters and persistent volumes. It works both on premises and in a public cloud.
 author_name: Velero Team
 # author_avatar: https://placehold.it/64x64
 categories: ['kubernetes']
 # Tag should match author to drive author pages
 tags: ['Velero Team']
 ---
-Velero is an open source tool to safely back up, recover, and migrate Kubernetes clusters and persistent volumes. It works both on premises and in a public cloud.<!--more--> Velero consists of a server process running as a deployment in your Kubernetes cluster and a command-line interface (CLI) with which DevOps teams and platform operators configure scheduled backups, trigger ad-hoc backups, perform restores, and more.
+Velero is an open source tool to safely back up, recover, and migrate Kubernetes clusters and persistent volumes. It works both on premises and in a public cloud. Velero consists of a server process running as a deployment in your Kubernetes cluster and a command-line interface (CLI) with which DevOps teams and platform operators configure scheduled backups, trigger ad-hoc backups, perform restores, and more.
 
 ## What Makes Velero Stand Out?
 Unlike other tools which directly access the Kubernetes etcd database to perform backups and restores, Velero uses the Kubernetes API to capture the state of cluster resources and to restore them when necessary. This API-driven approach has a number of key benefits:

--- a/site/_posts/2019-05-20-velero-1.0-has-arrived.md
+++ b/site/_posts/2019-05-20-velero-1.0-has-arrived.md
@@ -1,14 +1,14 @@
 ---
 title: Velero 1.0 Has Arrived&#58; Delivering Enhanced Stability, Usability and Extensibility Features
 # image: https://placehold.it/200x200
-excerpt_separator: <!--more-->
+excerpt: Just three months after the release of Velero 0.11, the community’s momentum continues with the delivery of the landmark version 1.0 release.
 author_name: Tom Spoonemore
 # author_avatar: https://placehold.it/64x64
 categories: ['velero','release']
 # Tag should match author to drive author pages
 tags: ['Velero Team', 'Tom Spoonemore']
 ---
-Just three months after the release of Velero 0.11, the community’s momentum continues with the delivery of the landmark version 1.0 release. <!--more--> This significant release improves the installation experience, Helm support, the plugin system, and overall stability. We want to thank the community and the team, and acknowledge all of their hard work and amazing contributions to this major milestone.
+Just three months after the release of Velero 0.11, the community’s momentum continues with the delivery of the landmark version 1.0 release. This significant release improves the installation experience, Helm support, the plugin system, and overall stability. We want to thank the community and the team, and acknowledge all of their hard work and amazing contributions to this major milestone.
 
 Data protection is always a chief concern for application owners who want to make sure that they can restore a cluster to a known good state, recover from a crashed cluster, or migrate to a new environment. With Velero 1.0, Kubernetes cluster administrators can feel confident that they have a production-grade backup solution for their cluster resources and applications.
 


### PR DESCRIPTION
Fixes #1575 

After doing some research, it seems like this is an issue with the way that the redcarpet md rendered works. There were issues opened a few years back related to this, but it has since gone back and forth with reverts as well as alternative solutions. Alternative solutions include switching renderers or explicitly specifying the page excerpt in the post. I also looked at using different separators than '<!--more-->', but did not have any more success. I'm not super pleased with this solution as it duplicates text. Open to better suggestions.

https://github.com/jekyll/jekyll/issues/1839
https://github.com/vmg/redcarpet/issues/268
