### PR TITLE
Add redirect for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can run Velero in clusters on a cloud provider or on-premises. For detailed 
 
 ## Installation
 
-We strongly recommend that you use an [official release][6] of Velero. The tarballs for each release contain the 
+We strongly recommend that you use an [official release][6] of Velero. The tarballs for each release contain the
 `velero` command-line client. Follow the instructions under the **Install** section of [our documentation][29] to get started.
 
 _The code and sample YAML files in the master branch of the Velero repository are under active development and are not guaranteed to be stable. Use them at your own risk!_
@@ -70,11 +70,11 @@ See [the list of releases][6] to find out about feature changes.
 
 [24]: https://groups.google.com/forum/#!forum/projectvelero
 [25]: https://kubernetes.slack.com/messages/velero
-[26]: https://velero.io/docs/v1.0.0/zenhub
+[26]: https://velero.io/docs/zenhub
 
 
-[29]: https://velero.io/docs/v1.0.0/
-[30]: https://velero.io/docs/v1.0.0/troubleshooting
+[29]: https://velero.io/docs/
+[30]: https://velero.io/docs/troubleshooting
 
-[99]: https://velero.io/docs/v1.0.0/support-matrix
+[99]: https://velero.io/docs/support-matrix
 [100]: /site/docs/master/img/velero.png

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -157,7 +157,7 @@ plugins:
   - jekyll-optional-front-matter # Parse Markdown files that do not have front-matter callouts
   - jekyll-titles-from-headings # pull the page title from the first Markdown heading when none is specified.
   - jekyll-paginate # pagination object for collections (e.g. posts)
-
+  - jekyll-redirect-from
 
 # Include these subdirectories
 include:

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -164,7 +164,6 @@ plugins:
   - jekyll-titles-from-headings # pull the page title from the first Markdown heading when none is specified.
   - jekyll-paginate # pagination object for collections (e.g. posts)
   - jekyll-redirect-from
-#  - data_page_generator
 
 # Include these subdirectories
 include:

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -121,6 +121,12 @@ defaults:
       gh: https://github.com/heptio/velero/tree/v0.3.0
       layout: "docs"
 
+page_gen:
+  - data: shortlinks
+    template: redirect
+    name: key
+    dir: docs
+
 collections:
   - contributors
   - casestudies
@@ -158,6 +164,7 @@ plugins:
   - jekyll-titles-from-headings # pull the page title from the first Markdown heading when none is specified.
   - jekyll-paginate # pagination object for collections (e.g. posts)
   - jekyll-redirect-from
+#  - data_page_generator
 
 # Include these subdirectories
 include:

--- a/site/_data/shortlinks.yml
+++ b/site/_data/shortlinks.yml
@@ -1,0 +1,9 @@
+- title: Troubleshooting
+  key: troubleshooting
+  destination: troubleshooting
+- title: Support Matrix
+  key: support-matrix
+  destination: support-matrix
+- title: ZenHub
+  key: zenhub
+  destination: zenhub

--- a/site/_layouts/redirect.html
+++ b/site/_layouts/redirect.html
@@ -1,0 +1,18 @@
+{% assign parts = page.redirect.to | split: "/" %}
+{% assign basename = parts.last %}
+{% if basename == 'LATEST' %}
+  {% assign destination = "docs/" | append:site.latest | absolute_url %}
+{% else %}
+  {% assign destination = page.redirect.to %}
+{% endif %}
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ destination }}">
+  <meta http-equiv="refresh" content="0; url={{ destination }}">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ destination }}">Click here if you are not redirected.</a>
+  <script>location="{{ destination }}"</script>
+</html>

--- a/site/_layouts/redirect.html
+++ b/site/_layouts/redirect.html
@@ -1,18 +1,13 @@
-{% assign parts = page.redirect.to | split: "/" %}
-{% assign basename = parts.last %}
-{% if basename == 'LATEST' %}
-  {% assign destination = "docs/" | append:site.latest | absolute_url %}
-{% else %}
-  {% assign destination = page.redirect.to %}
-{% endif %}
 <!DOCTYPE html>
-<html lang="en-US">
-  <meta charset="utf-8">
-  <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="{{ destination }}">
-  <meta http-equiv="refresh" content="0; url={{ destination }}">
-  <meta name="robots" content="noindex">
-  <h1>Redirecting&hellip;</h1>
-  <a href="{{ destination }}">Click here if you are not redirected.</a>
-  <script>location="{{ destination }}"</script>
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="0; url=/docs/{{ site.latest }}/{{ page.destination }}" />
+  <script type="text/javascript">
+    window.location.href = "/docs/{{ site.latest }}/{{ page.destination }}"
+  </script>
+  <title>Redirecting...</title>
+</head>
+<body>
+Redirecting to {{ page.destination }}. If it doesn't load, click <a href="/docs/{{ site.latest }}/{{ page.destination }}" />here</a>.
+</body>
 </html>

--- a/site/_plugins/data_page_generator.rb
+++ b/site/_plugins/data_page_generator.rb
@@ -1,0 +1,135 @@
+# coding: utf-8
+# Generate pages from individual records in yml files
+# (c) 2014-2016 Adolfo Villafiorita
+# Distributed under the conditions of the MIT License
+
+module Jekyll
+
+  module Sanitizer
+    # strip characters and whitespace to create valid filenames, also lowercase
+    def sanitize_filename(name)
+      if(name.is_a? Integer)
+        return name.to_s
+      end
+      return name.tr(
+  "ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÑñÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž",
+  "AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz"
+).downcase.strip.gsub(' ', '-').gsub(/[^\w.-]/, '')
+    end
+  end
+
+  # this class is used to tell Jekyll to generate a page
+  class DataPage < Page
+    include Sanitizer
+
+    # - site and base are copied from other plugins: to be honest, I am not sure what they do
+    #
+    # - `index_files` specifies if we want to generate named folders (true) or not (false)
+    # - `dir` is the default output directory
+    # - `data` is the data defined in `_data.yml` of the record for which we are generating a page
+    # - `name` is the key in `data` which determines the output filename
+    # - `template` is the name of the template for generating the page
+    # - `extension` is the extension for the generated file
+    def initialize(site, base, index_files, dir, data, name, template, extension)
+      @site = site
+      @base = base
+
+      # @dir is the directory where we want to output the page
+      # @name is the name of the page to generate
+      #
+      # the value of these variables changes according to whether we
+      # want to generate named folders or not
+      if data[name] == nil
+        puts "error (datapage_gen). empty value for field '#{name}' in record #{data}"
+      else
+        filename = sanitize_filename(data[name]).to_s
+
+        @dir = dir + (index_files ? "/" + filename + "/" : "")
+        @name = (index_files ? "index" : filename) + "." + extension.to_s
+
+        self.process(@name)
+        self.read_yaml(File.join(base, '_layouts'), template + ".html")
+        self.data['title'] = data[name]
+        # add all the information defined in _data for the current record to the
+        # current page (so that we can access it with liquid tags)
+        self.data.merge!(data)
+      end
+    end
+  end
+
+  class DataPagesGenerator < Generator
+    safe true
+
+    # generate loops over _config.yml/page_gen invoking the DataPage
+    # constructor for each record for which we want to generate a page
+
+    def generate(site)
+      # page_gen_dirs determines whether we want to generate index pages
+      # (name/index.html) or standard files (name.html). This information
+      # is passed to the DataPage constructor, which sets the @dir variable
+      # as required by this directive
+      index_files = site.config['page_gen-dirs'] == true
+
+      # data contains the specification of the data for which we want to generate
+      # the pages (look at the README file for its specification)
+      data = site.config['page_gen']
+      if data
+        data.each do |data_spec|
+          index_files_for_this_data = data_spec['index_files'] != nil ? data_spec['index_files'] : index_files
+          template = data_spec['template'] || data_spec['data']
+          name = data_spec['name']
+          dir = data_spec['dir'] || data_spec['data']
+          extension = data_spec['extension'] || "html"
+
+          if site.layouts.key? template
+            # records is the list of records defined in _data.yml
+            # for which we want to generate different pages
+            records = nil
+            data_spec['data'].split('.').each do |level|
+              if records.nil?
+                records = site.data[level]
+              else
+                records = records[level]
+              end
+            end
+
+            # apply filtering conditions:
+            # - filter requires the name of a boolean field
+            # - filter_condition evals a ruby expression
+            records = records.select { |r| r[data_spec['filter']] } if data_spec['filter']
+            records = records.select { |record| eval(data_spec['filter_condition']) } if data_spec['filter_condition']
+
+            records.each do |record|
+              site.pages << DataPage.new(site, site.source, index_files_for_this_data, dir, record, name, template, extension)
+            end
+          else
+            puts "error (datapage_gen). could not find template #{template}" if not site.layouts.key? template
+          end
+        end
+      end
+    end
+  end
+
+  module DataPageLinkGenerator
+    include Sanitizer
+
+    # use it like this: {{input | datapage_url: dir}}
+    # to generate a link to a data_page.
+    #
+    # the filter is smart enough to generate different link styles
+    # according to the data_page-dirs directive ...
+    #
+    # ... however, the filter is not smart enough to support different
+    # extensions for filenames.
+    #
+    # Thus, if you use the `extension` feature of this plugin, you
+    # need to generate the links by hand
+    def datapage_url(input, dir)
+      extension = Jekyll.configuration({})['page_gen-dirs'] ? '/' : '.html'
+      "#{dir}/#{sanitize_filename(input)}#{extension}"
+    end
+  end
+
+end
+
+Liquid::Template.register_filter(Jekyll::DataPageLinkGenerator)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,0 +1,4 @@
+---
+redirect_from: "docs/latest"
+redirect_to: "docs/v1.0.0"
+---

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,4 +1,4 @@
 ---
-redirect_from: "docs/latest"
-redirect_to: "docs/v1.0.0"
+redirect_to:
+- LATEST
 ---


### PR DESCRIPTION
This will add a redirect for https://velero.io/docs and https://velero.io/docs/latest.

Fixes #1563.

Signed-off-by: jonasrosland <jrosland@vmware.com>