### PR TITLE
ensure backup item action modifications reflected in tarball filepath

### DIFF
--- a/changelogs/unreleased/1587-prydonius
+++ b/changelogs/unreleased/1587-prydonius
@@ -1,0 +1,1 @@
+ensures backup item action modifications to an item's namespace/name are saved in the file path in the tarball

--- a/pkg/backup/backup_new_test.go
+++ b/pkg/backup/backup_new_test.go
@@ -1006,8 +1006,7 @@ func TestBackupActionModifications(t *testing.T) {
 			},
 		},
 		{
-			// TODO this seems like a bug
-			name: "modifications to name and namespace in an action are persisted in JSON but not in filename",
+			name: "modifications to name and namespace in an action are persisted in JSON and in filename",
 			backup: defaultBackup().
 				Backup(),
 			apiResources: []*apiResource{
@@ -1022,7 +1021,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, newPod("ns-1-updated", "pod-1-updated")),
+				"resources/pods/namespaces/ns-1-updated/pod-1-updated.json": toUnstructuredOrFail(t, newPod("ns-1-updated", "pod-1-updated")),
 			},
 		},
 	}

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -206,6 +206,9 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 	if metadata, err = meta.Accessor(obj); err != nil {
 		return errors.WithStack(err)
 	}
+	// update name and namespace in case they were modified in an action
+	name = metadata.GetName()
+	namespace = metadata.GetNamespace()
 
 	if groupResource == kuberesource.PersistentVolumes {
 		if err := ib.takePVSnapshot(obj, log); err != nil {


### PR DESCRIPTION
This patch ensures the updated backup item's name and namespace are used
when constructing the filepath for the tarball.

fixes #1553 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>