### PR TITLE
allow exclusion of resources using standard label

### DIFF
--- a/changelogs/unreleased/1588-prydonius
+++ b/changelogs/unreleased/1588-prydonius
@@ -1,0 +1,1 @@
+allows excluding resources from backups with the velero.io/exclude-from-backup=true label

--- a/pkg/backup/backup_new_test.go
+++ b/pkg/backup/backup_new_test.go
@@ -249,16 +249,16 @@ func TestBackupResourceFiltering(t *testing.T) {
 				Backup(),
 			apiResources: []*apiResource{
 				pods(
-					withLabel(withLabel(newPod("foo", "bar"), "velero.io/exclude-from-backup", "true"), "a", "b"),
+					withLabel(newPod("foo", "bar"), "velero.io/exclude-from-backup", "true", "a", "b"),
 					withLabel(newPod("zoo", "raz"), "a", "b"),
 				),
 				deployments(
 					newDeployment("foo", "bar"),
-					withLabel(withLabel(newDeployment("zoo", "raz"), "velero.io/exclude-from-backup", "true"), "a", "b"),
+					withLabel(newDeployment("zoo", "raz"), "velero.io/exclude-from-backup", "true", "a", "b"),
 				),
 				pvs(
 					withLabel(newPV("bar"), "a", "b"),
-					withLabel(withLabel(newPV("baz"), "a", "b"), "velero.io/exclude-from-backup", "true"),
+					withLabel(newPV("baz"), "a", "b", "velero.io/exclude-from-backup", "true"),
 				),
 			},
 			want: []string{
@@ -1870,12 +1870,14 @@ func newHarness(t *testing.T) *harness {
 	}
 }
 
-func withLabel(obj metav1.Object, key, val string) metav1.Object {
+func withLabel(obj metav1.Object, labelPairs ...string) metav1.Object {
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[key] = val
+	for i := 0; i < len(labelPairs); i += 2 {
+		labels[labelPairs[i]] = labelPairs[i+1]
+	}
 	obj.SetLabels(labels)
 
 	return obj

--- a/pkg/backup/backup_new_test.go
+++ b/pkg/backup/backup_new_test.go
@@ -1871,6 +1871,9 @@ func newHarness(t *testing.T) *harness {
 }
 
 func withLabel(obj metav1.Object, labelPairs ...string) metav1.Object {
+	if len(labelPairs)%2 != 0 {
+		panic("withLabel requires a series of key-value pairs")
+	}
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)

--- a/pkg/backup/resource_backupper.go
+++ b/pkg/backup/resource_backupper.go
@@ -221,9 +221,7 @@ func (rb *defaultResourceBackupper) backupResource(group *metav1.APIResourceList
 			continue
 		}
 
-		var labelSelector string
-		excludeLabelSelector := "velero.io/exclude-from-backup!=true"
-		labelSelector = excludeLabelSelector
+		labelSelector := "velero.io/exclude-from-backup!=true"
 		if selector := rb.backupRequest.Spec.LabelSelector; selector != nil {
 			labelSelector = labelSelector + "," + metav1.FormatLabelSelector(selector)
 		}

--- a/pkg/backup/resource_backupper.go
+++ b/pkg/backup/resource_backupper.go
@@ -222,8 +222,10 @@ func (rb *defaultResourceBackupper) backupResource(group *metav1.APIResourceList
 		}
 
 		var labelSelector string
+		excludeLabelSelector := "velero.io/exclude-from-backup!=true"
+		labelSelector = excludeLabelSelector
 		if selector := rb.backupRequest.Spec.LabelSelector; selector != nil {
-			labelSelector = metav1.FormatLabelSelector(selector)
+			labelSelector = labelSelector + "," + metav1.FormatLabelSelector(selector)
 		}
 
 		log.Info("Listing items")


### PR DESCRIPTION
excludes any resources with the velero.io/exclude-from-backup=true label

fixes #1373 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>