### PR TITLE
Add more community info - direct links to meetings and ZenHub

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -7,12 +7,12 @@ id: community
 
 If you’re a newcomer, check out the “[Good first issue](https://github.com/heptio/velero/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22)” and “[Help wanted](https://github.com/heptio/velero/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+)” labels in the Velero repository.
 
+You can follow the work we do, see our milestones, and our backlog on our [ZenHub board](https://app.zenhub.com/workspace/o/heptio/velero/boards?filterLogic=all&repos=99143276).
+
 * Follow us on Twitter at [@projectvelero](https://twitter.com/projectvelero)
-
 * Join our Kubernetes Slack channel and talk to over 800 other community members: [#velero](https://kubernetes.slack.com/messages/velero)
-
 * Join our [Google Group](https://groups.google.com/forum/#!forum/projectvelero) to get updates on the project and invites to community meetings.
-
-* Join the Velero community meetings every 1st and 3rd Tuesday: <https://github.com/heptio/velero-community>
-
+* Join the [Velero community meetings](https://github.com/heptio/velero-community):
+  - Every 1st Tuesday - [Zoom link](https://vmware.zoom.us/j/551441444)
+  - Every 3rd Tuesday - [Zoom link](https://vmware.zoom.us/j/324372812)
 * See previous community meetings on our [YouTube Channel](https://www.youtube.com/playlist?list=PL7bmigfV0EqQRysvqvqOtRNk4L5S7uqwM)


### PR DESCRIPTION
This will add direct links to community meetings, and a link to ZenHub to follow the work being done.

This fixes #1523.

Signed-off-by: jonasrosland <jrosland@vmware.com>