### PR TITLE
Migrate restore tests to new structure (part 1)

### DIFF
--- a/pkg/backup/backup_new_test.go
+++ b/pkg/backup/backup_new_test.go
@@ -196,16 +196,16 @@ func TestBackupResourceFiltering(t *testing.T) {
 				Backup(),
 			apiResources: []*test.APIResource{
 				test.Pods(
-					withLabel(test.NewPod("foo", "bar"), "a", "b"),
+					test.NewPod("foo", "bar", test.WithLabels("a", "b")),
 					test.NewPod("zoo", "raz"),
 				),
 				test.Deployments(
 					test.NewDeployment("foo", "bar"),
-					withLabel(test.NewDeployment("zoo", "raz"), "a", "b"),
+					test.NewDeployment("zoo", "raz", test.WithLabels("a", "b")),
 				),
 				test.PVs(
-					withLabel(test.NewPV("bar"), "a", "b"),
-					withLabel(test.NewPV("baz"), "a", "c"),
+					test.NewPV("bar", test.WithLabels("a", "b")),
+					test.NewPV("baz", test.WithLabels("a", "c")),
 				),
 			},
 			want: []string{
@@ -220,16 +220,16 @@ func TestBackupResourceFiltering(t *testing.T) {
 				Backup(),
 			apiResources: []*test.APIResource{
 				test.Pods(
-					withLabel(test.NewPod("foo", "bar"), "velero.io/exclude-from-backup", "true"),
+					test.NewPod("foo", "bar", test.WithLabels("velero.io/exclude-from-backup", "true")),
 					test.NewPod("zoo", "raz"),
 				),
 				test.Deployments(
 					test.NewDeployment("foo", "bar"),
-					withLabel(test.NewDeployment("zoo", "raz"), "velero.io/exclude-from-backup", "true"),
+					test.NewDeployment("zoo", "raz", test.WithLabels("velero.io/exclude-from-backup", "true")),
 				),
 				test.PVs(
-					withLabel(test.NewPV("bar"), "a", "b"),
-					withLabel(test.NewPV("baz"), "velero.io/exclude-from-backup", "true"),
+					test.NewPV("bar", test.WithLabels("a", "b")),
+					test.NewPV("baz", test.WithLabels("velero.io/exclude-from-backup", "true")),
 				),
 			},
 			want: []string{
@@ -245,16 +245,16 @@ func TestBackupResourceFiltering(t *testing.T) {
 				Backup(),
 			apiResources: []*test.APIResource{
 				test.Pods(
-					withLabel(test.NewPod("foo", "bar"), "velero.io/exclude-from-backup", "true", "a", "b"),
-					withLabel(test.NewPod("zoo", "raz"), "a", "b"),
+					test.NewPod("foo", "bar", test.WithLabels("velero.io/exclude-from-backup", "true", "a", "b")),
+					test.NewPod("zoo", "raz", test.WithLabels("a", "b")),
 				),
 				test.Deployments(
 					test.NewDeployment("foo", "bar"),
-					withLabel(test.NewDeployment("zoo", "raz"), "velero.io/exclude-from-backup", "true", "a", "b"),
+					test.NewDeployment("zoo", "raz", test.WithLabels("velero.io/exclude-from-backup", "true", "a", "b")),
 				),
 				test.PVs(
-					withLabel(test.NewPV("bar"), "a", "b"),
-					withLabel(test.NewPV("baz"), "a", "b", "velero.io/exclude-from-backup", "true"),
+					test.NewPV("bar", test.WithLabels("a", "b")),
+					test.NewPV("baz", test.WithLabels("a", "b", "velero.io/exclude-from-backup", "true")),
 				),
 			},
 			want: []string{
@@ -268,16 +268,16 @@ func TestBackupResourceFiltering(t *testing.T) {
 				Backup(),
 			apiResources: []*test.APIResource{
 				test.Pods(
-					withLabel(test.NewPod("foo", "bar"), "velero.io/exclude-from-backup", "false"),
+					test.NewPod("foo", "bar", test.WithLabels("velero.io/exclude-from-backup", "false")),
 					test.NewPod("zoo", "raz"),
 				),
 				test.Deployments(
 					test.NewDeployment("foo", "bar"),
-					withLabel(test.NewDeployment("zoo", "raz"), "velero.io/exclude-from-backup", "1"),
+					test.NewDeployment("zoo", "raz", test.WithLabels("velero.io/exclude-from-backup", "1")),
 				),
 				test.PVs(
-					withLabel(test.NewPV("bar"), "a", "b"),
-					withLabel(test.NewPV("baz"), "velero.io/exclude-from-backup", ""),
+					test.NewPV("bar", test.WithLabels("a", "b")),
+					test.NewPV("baz", test.WithLabels("velero.io/exclude-from-backup", "")),
 				),
 			},
 			want: []string{
@@ -1042,7 +1042,7 @@ func TestBackupActionModifications(t *testing.T) {
 				}),
 			},
 			want: map[string]unstructuredObject{
-				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, withLabel(test.NewPod("ns-1", "pod-1"), "updated", "true")),
+				"resources/pods/namespaces/ns-1/pod-1.json": toUnstructuredOrFail(t, test.NewPod("ns-1", "pod-1", test.WithLabels("updated", "true"))),
 			},
 		},
 		{
@@ -1050,7 +1050,7 @@ func TestBackupActionModifications(t *testing.T) {
 			backup: defaultBackup().Backup(),
 			apiResources: []*test.APIResource{
 				test.Pods(
-					withLabel(test.NewPod("ns-1", "pod-1"), "should-be-removed", "true"),
+					test.NewPod("ns-1", "pod-1", test.WithLabels("should-be-removed", "true")),
 				),
 			},
 			actions: []velero.BackupItemAction{
@@ -1509,7 +1509,7 @@ func TestBackupWithSnapshots(t *testing.T) {
 			},
 			apiResources: []*test.APIResource{
 				test.PVs(
-					withLabel(test.NewPV("pv-1"), "failure-domain.beta.kubernetes.io/zone", "zone-1"),
+					test.NewPV("pv-1", test.WithLabels("failure-domain.beta.kubernetes.io/zone", "zone-1")),
 				),
 			},
 			snapshotterGetter: map[string]velero.VolumeSnapshotter{
@@ -2086,22 +2086,6 @@ func newHarness(t *testing.T) *harness {
 		},
 		log: log,
 	}
-}
-
-func withLabel(obj metav1.Object, labelPairs ...string) metav1.Object {
-	if len(labelPairs)%2 != 0 {
-		panic("withLabel requires a series of key-value pairs")
-	}
-	labels := obj.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-	for i := 0; i < len(labelPairs); i += 2 {
-		labels[labelPairs[i]] = labelPairs[i+1]
-	}
-	obj.SetLabels(labels)
-
-	return obj
 }
 
 func newSnapshotLocation(ns, name, provider string) *velerov1.VolumeSnapshotLocation {

--- a/pkg/restore/builder.go
+++ b/pkg/restore/builder.go
@@ -60,6 +60,42 @@ func (b *Builder) Backup(name string) *Builder {
 	return b
 }
 
+// IncludedNamespaces sets the Restore's included namespaces.
+func (b *Builder) IncludedNamespaces(namespaces ...string) *Builder {
+	b.restore.Spec.IncludedNamespaces = namespaces
+	return b
+}
+
+// ExcludedNamespaces sets the Restore's excluded namespaces.
+func (b *Builder) ExcludedNamespaces(namespaces ...string) *Builder {
+	b.restore.Spec.ExcludedNamespaces = namespaces
+	return b
+}
+
+// IncludedResources sets the Restore's included resources.
+func (b *Builder) IncludedResources(resources ...string) *Builder {
+	b.restore.Spec.IncludedResources = resources
+	return b
+}
+
+// ExcludedResources sets the Restore's excluded resources.
+func (b *Builder) ExcludedResources(resources ...string) *Builder {
+	b.restore.Spec.ExcludedResources = resources
+	return b
+}
+
+// IncludeClusterResources sets the Restore's "include cluster resources" flag.
+func (b *Builder) IncludeClusterResources(val bool) *Builder {
+	b.restore.Spec.IncludeClusterResources = &val
+	return b
+}
+
+// LabelSelector sets the Restore's label selector.
+func (b *Builder) LabelSelector(selector *metav1.LabelSelector) *Builder {
+	b.restore.Spec.LabelSelector = selector
+	return b
+}
+
 // NamespaceMappings sets the Restore's namespace mappings.
 func (b *Builder) NamespaceMappings(mapping ...string) *Builder {
 	if b.restore.Spec.NamespaceMapping == nil {

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -134,42 +134,6 @@ func TestRestorePriority(t *testing.T) {
 		expectedReadDirs     []string
 	}{
 		{
-			name:       "cluster test",
-			fileSystem: velerotest.NewFakeFileSystem().WithDirectory("bak/resources/a/cluster").WithDirectory("bak/resources/c/cluster"),
-			baseDir:    "bak",
-			restore:    &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"*"}}},
-			prioritizedResources: []schema.GroupResource{
-				{Resource: "a"},
-				{Resource: "b"},
-				{Resource: "c"},
-			},
-			expectedReadDirs: []string{"bak/resources", "bak/resources/a/cluster", "bak/resources/c/cluster"},
-		},
-		{
-			name:       "resource priorities are applied",
-			fileSystem: velerotest.NewFakeFileSystem().WithDirectory("bak/resources/a/cluster").WithDirectory("bak/resources/c/cluster"),
-			restore:    &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"*"}}},
-			baseDir:    "bak",
-			prioritizedResources: []schema.GroupResource{
-				{Resource: "c"},
-				{Resource: "b"},
-				{Resource: "a"},
-			},
-			expectedReadDirs: []string{"bak/resources", "bak/resources/c/cluster", "bak/resources/a/cluster"},
-		},
-		{
-			name:       "basic namespace",
-			fileSystem: velerotest.NewFakeFileSystem().WithDirectory("bak/resources/a/namespaces/ns-1").WithDirectory("bak/resources/c/namespaces/ns-1"),
-			restore:    &api.Restore{Spec: api.RestoreSpec{IncludedNamespaces: []string{"*"}}},
-			baseDir:    "bak",
-			prioritizedResources: []schema.GroupResource{
-				{Resource: "a"},
-				{Resource: "b"},
-				{Resource: "c"},
-			},
-			expectedReadDirs: []string{"bak/resources", "bak/resources/a/namespaces", "bak/resources/a/namespaces/ns-1", "bak/resources/c/namespaces", "bak/resources/c/namespaces/ns-1"},
-		},
-		{
 			name: "error in a single resource doesn't terminate restore immediately, but is returned",
 			fileSystem: velerotest.NewFakeFileSystem().
 				WithFile("bak/resources/a/namespaces/ns-1/invalid-json.json", []byte("invalid json")).

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -121,69 +121,176 @@ func Namespaces(items ...metav1.Object) *APIResource {
 	}
 }
 
-func NewPod(ns, name string) *corev1.Pod {
-	return &corev1.Pod{
+func ServiceAccounts(items ...metav1.Object) *APIResource {
+	return &APIResource{
+		Group:      "",
+		Version:    "v1",
+		Name:       "serviceaccounts",
+		ShortName:  "sa",
+		Namespaced: true,
+		Items:      items,
+	}
+}
+
+type ObjectOpts func(metav1.Object)
+
+func NewPod(ns, name string, opts ...ObjectOpts) *corev1.Pod {
+	obj := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
 		},
 		ObjectMeta: objectMeta(ns, name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
-func NewPVC(ns, name string) *corev1.PersistentVolumeClaim {
-	return &corev1.PersistentVolumeClaim{
+func NewPVC(ns, name string, opts ...ObjectOpts) *corev1.PersistentVolumeClaim {
+	obj := &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
 			APIVersion: "v1",
 		},
 		ObjectMeta: objectMeta(ns, name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
-func NewPV(name string) *corev1.PersistentVolume {
-	return &corev1.PersistentVolume{
+func NewPV(name string, opts ...ObjectOpts) *corev1.PersistentVolume {
+	obj := &corev1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolume",
 			APIVersion: "v1",
 		},
 		ObjectMeta: objectMeta("", name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
-func NewSecret(ns, name string) *corev1.Secret {
-	return &corev1.Secret{
+func NewSecret(ns, name string, opts ...ObjectOpts) *corev1.Secret {
+	obj := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: objectMeta(ns, name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
-func NewDeployment(ns, name string) *appsv1.Deployment {
-	return &appsv1.Deployment{
+func NewDeployment(ns, name string, opts ...ObjectOpts) *appsv1.Deployment {
+	obj := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: objectMeta(ns, name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
-func NewNamespace(name string) *corev1.Namespace {
-	return &corev1.Namespace{
+func NewServiceAccount(ns, name string, opts ...ObjectOpts) *corev1.ServiceAccount {
+	obj := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: objectMeta(ns, name),
+	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
+}
+
+func NewNamespace(name string, opts ...ObjectOpts) *corev1.Namespace {
+	obj := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
 			APIVersion: "v1",
 		},
 		ObjectMeta: objectMeta("", name),
 	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
 }
 
 func objectMeta(ns, name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Namespace: ns,
 		Name:      name,
+	}
+}
+
+// WithLabels is a functional option that applies the specified
+// label keys/values to an object.
+func WithLabels(labels ...string) func(obj metav1.Object) {
+	return func(obj metav1.Object) {
+		objLabels := obj.GetLabels()
+		if objLabels == nil {
+			objLabels = make(map[string]string)
+		}
+
+		if len(labels)%2 != 0 {
+			labels = append(labels, "")
+		}
+
+		for i := 0; i < len(labels); i += 2 {
+			objLabels[labels[i]] = labels[i+1]
+		}
+
+		obj.SetLabels(objLabels)
+	}
+}
+
+// WithAnnotations is a functional option that applies the specified
+// annotation keys/values to an object.
+func WithAnnotations(vals ...string) func(obj metav1.Object) {
+	return func(obj metav1.Object) {
+		objAnnotations := obj.GetAnnotations()
+		if objAnnotations == nil {
+			objAnnotations = make(map[string]string)
+		}
+
+		if len(vals)%2 != 0 {
+			vals = append(vals, "")
+		}
+
+		for i := 0; i < len(vals); i += 2 {
+			objAnnotations[vals[i]] = vals[i+1]
+		}
+
+		obj.SetAnnotations(objAnnotations)
 	}
 }


### PR DESCRIPTION
Here's the first batch of migrated `pkg/restore` tests. Probably easiest to review one commit at a time.

These commits don't need to be squashed for merge.

cc @nrb @prydonius @carlisia 