### PR TITLE
Fix bugs in determining which restore item actions to run

### DIFF
--- a/changelogs/unreleased/1607-skriss
+++ b/changelogs/unreleased/1607-skriss
@@ -1,0 +1,1 @@
+bug fix: respect namespace selector when determining which restore item actions to run

--- a/pkg/restore/restore_new_test.go
+++ b/pkg/restore/restore_new_test.go
@@ -1060,6 +1060,34 @@ func TestRestoreActionsRunForCorrectItems(t *testing.T) {
 			},
 		},
 		{
+			name:    "single action with a namespace selector runs only for resources in that namespace",
+			restore: defaultRestore().Restore(),
+			backup:  defaultBackup().Backup(),
+			tarball: newTarWriter(t).
+				addItems("pods", test.NewPod("ns-1", "pod-1"), test.NewPod("ns-2", "pod-2")).
+				addItems("persistentvolumeclaims", test.NewPVC("ns-1", "pvc-1"), test.NewPVC("ns-2", "pvc-2")).
+				addItems("persistentvolumes", test.NewPV("pv-1"), test.NewPV("pv-2")).
+				done(),
+			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			actions: map[*recordResourcesAction][]string{
+				new(recordResourcesAction).ForNamespace("ns-1"): {"ns-1/pod-1", "ns-1/pvc-1"},
+			},
+		},
+		{
+			name:    "single action with a resource and namespace selector runs only for matching resources in that namespace",
+			restore: defaultRestore().Restore(),
+			backup:  defaultBackup().Backup(),
+			tarball: newTarWriter(t).
+				addItems("pods", test.NewPod("ns-1", "pod-1"), test.NewPod("ns-2", "pod-2")).
+				addItems("persistentvolumeclaims", test.NewPVC("ns-1", "pvc-1"), test.NewPVC("ns-2", "pvc-2")).
+				addItems("persistentvolumes", test.NewPV("pv-1"), test.NewPV("pv-2")).
+				done(),
+			apiResources: []*test.APIResource{test.Pods(), test.PVCs(), test.PVs()},
+			actions: map[*recordResourcesAction][]string{
+				new(recordResourcesAction).ForNamespace("ns-1").ForResource("pods"): {"ns-1/pod-1"},
+			},
+		},
+		{
 			name:    "multiple actions, each with a different resource selector using short name, run for matching resources",
 			restore: defaultRestore().Restore(),
 			backup:  defaultBackup().Backup(),

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -337,14 +337,13 @@ status:
 						Name:      "my-restore",
 					},
 				},
-				backup:            backup,
-				log:               velerotest.NewLogger(),
-				pvsToProvision:    sets.NewString(),
-				pvRestorer:        pvRestorer,
-				namespaceClient:   nsClient,
-				applicableActions: make(map[schema.GroupResource][]resolvedAction),
-				resourceClients:   make(map[resourceClientKey]pkgclient.Dynamic),
-				restoredItems:     make(map[velero.ResourceIdentifier]struct{}),
+				backup:          backup,
+				log:             velerotest.NewLogger(),
+				pvsToProvision:  sets.NewString(),
+				pvRestorer:      pvRestorer,
+				namespaceClient: nsClient,
+				resourceClients: make(map[resourceClientKey]pkgclient.Dynamic),
+				restoredItems:   make(map[velero.ResourceIdentifier]struct{}),
 			}
 
 			if test.haveSnapshot {


### PR DESCRIPTION
Note: only the last commit is unique to this PR, the previous ones are from #1606. I'll rebase this after #1606 gets merged.

There were a couple of bugs related to determining which restore item actions to run for a resource, all around the use of namespace selectors -- essentially they were being ignored.

@nrb @prydonius @carlisia 