### PR TITLE
Append "/mount" to directory for CSI volumes

### DIFF
--- a/changelogs/unreleased/1615-nrb
+++ b/changelogs/unreleased/1615-nrb
@@ -1,0 +1,1 @@
+Add restic support for CSI volumes

--- a/pkg/cmd/cli/restic/server.go
+++ b/pkg/cmd/cli/restic/server.go
@@ -165,6 +165,7 @@ func (s *resticServer) run() {
 		s.podInformer,
 		s.secretInformer,
 		s.kubeInformerFactory.Core().V1().PersistentVolumeClaims(),
+		s.kubeInformerFactory.Core().V1().PersistentVolumes(),
 		s.veleroInformerFactory.Velero().V1().BackupStorageLocations(),
 		os.Getenv("NODE_NAME"),
 	)
@@ -181,6 +182,7 @@ func (s *resticServer) run() {
 		s.podInformer,
 		s.secretInformer,
 		s.kubeInformerFactory.Core().V1().PersistentVolumeClaims(),
+		s.kubeInformerFactory.Core().V1().PersistentVolumes(),
 		s.veleroInformerFactory.Velero().V1().BackupStorageLocations(),
 		os.Getenv("NODE_NAME"),
 	)

--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -51,6 +51,7 @@ type podVolumeBackupController struct {
 	secretLister          corev1listers.SecretLister
 	podLister             corev1listers.PodLister
 	pvcLister             corev1listers.PersistentVolumeClaimLister
+	pvLister              corev1listers.PersistentVolumeLister
 	backupLocationLister  listers.BackupStorageLocationLister
 	nodeName              string
 
@@ -67,6 +68,7 @@ func NewPodVolumeBackupController(
 	podInformer cache.SharedIndexInformer,
 	secretInformer cache.SharedIndexInformer,
 	pvcInformer corev1informers.PersistentVolumeClaimInformer,
+	pvInformer corev1informers.PersistentVolumeInformer,
 	backupLocationInformer informers.BackupStorageLocationInformer,
 	nodeName string,
 ) Interface {
@@ -77,6 +79,7 @@ func NewPodVolumeBackupController(
 		podLister:             corev1listers.NewPodLister(podInformer.GetIndexer()),
 		secretLister:          corev1listers.NewSecretLister(secretInformer.GetIndexer()),
 		pvcLister:             pvcInformer.Lister(),
+		pvLister:              pvInformer.Lister(),
 		backupLocationLister:  backupLocationInformer.Lister(),
 		nodeName:              nodeName,
 
@@ -191,7 +194,7 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 		return c.fail(req, errors.Wrap(err, "error getting pod").Error(), log)
 	}
 
-	volumeDir, err := kube.GetVolumeDirectory(pod, req.Spec.Volume, c.pvcLister)
+	volumeDir, err := kube.GetVolumeDirectory(pod, req.Spec.Volume, c.pvcLister, c.pvLister)
 	if err != nil {
 		log.WithError(err).Error("Error getting volume directory name")
 		return c.fail(req, errors.Wrap(err, "error getting volume directory name").Error(), log)

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -55,6 +55,7 @@ type podVolumeRestoreController struct {
 	podLister              corev1listers.PodLister
 	secretLister           corev1listers.SecretLister
 	pvcLister              corev1listers.PersistentVolumeClaimLister
+	pvLister               corev1listers.PersistentVolumeLister
 	backupLocationLister   listers.BackupStorageLocationLister
 	nodeName               string
 
@@ -71,6 +72,7 @@ func NewPodVolumeRestoreController(
 	podInformer cache.SharedIndexInformer,
 	secretInformer cache.SharedIndexInformer,
 	pvcInformer corev1informers.PersistentVolumeClaimInformer,
+	pvInformer corev1informers.PersistentVolumeInformer,
 	backupLocationInformer informers.BackupStorageLocationInformer,
 	nodeName string,
 ) Interface {
@@ -81,6 +83,7 @@ func NewPodVolumeRestoreController(
 		podLister:              corev1listers.NewPodLister(podInformer.GetIndexer()),
 		secretLister:           corev1listers.NewSecretLister(secretInformer.GetIndexer()),
 		pvcLister:              pvcInformer.Lister(),
+		pvLister:               pvInformer.Lister(),
 		backupLocationLister:   backupLocationInformer.Lister(),
 		nodeName:               nodeName,
 
@@ -276,7 +279,7 @@ func (c *podVolumeRestoreController) processRestore(req *velerov1api.PodVolumeRe
 		return c.failRestore(req, errors.Wrap(err, "error getting pod").Error(), log)
 	}
 
-	volumeDir, err := kube.GetVolumeDirectory(pod, req.Spec.Volume, c.pvcLister)
+	volumeDir, err := kube.GetVolumeDirectory(pod, req.Spec.Volume, c.pvcLister, c.pvLister)
 	if err != nil {
 		log.WithError(err).Error("Error getting volume directory name")
 		return c.failRestore(req, errors.Wrap(err, "error getting volume directory name").Error(), log)

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1752,7 +1752,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 				).
 				addItems("persistentvolumeclaims",
 					test.NewPVC("ns-1", "pvc-1",
-						test.WithVolumeName("pv-1"),
+						test.WithPVName("pv-1"),
 						test.WithAnnotations("pv.kubernetes.io/bind-completed", "true", "pv.kubernetes.io/bound-by-controller", "true", "foo", "bar"),
 					),
 				).


### PR DESCRIPTION
CSI volumes are mounted one level deeper than "native" kubernetes
volumes, and this needs to be appended for proper restic support.

Fixes #1313.

Currently a draft as I would like to get some tests in here, plus I need to verify it manually.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>