### PR TITLE
validate pod volumes hostpath mount on restic server startup

### DIFF
--- a/changelogs/unreleased/1616-prydonius
+++ b/changelogs/unreleased/1616-prydonius
@@ -1,0 +1,1 @@
+adds validation for pod volumes hostPath mount on restic server startup

--- a/pkg/cmd/cli/restic/server.go
+++ b/pkg/cmd/cli/restic/server.go
@@ -219,7 +219,7 @@ func (s *resticServer) validatePodVolumesHostPath() error {
 		}
 	}
 
-	pods, err := s.kubeClient.CoreV1().Pods("").List(metav1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s", os.Getenv("NODE_NAME"))})
+	pods, err := s.kubeClient.CoreV1().Pods("").List(metav1.ListOptions{FieldSelector: fmt.Sprintf("spec.nodeName=%s,status.phase=Running", os.Getenv("NODE_NAME"))})
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -244,7 +244,7 @@ func (s *resticServer) validatePodVolumesHostPath() error {
 	}
 
 	if !valid {
-		return errors.New("unexpected directory structure for pod volumes path, check if the pod volumes hostPath mount is correct")
+		return errors.New("unexpected directory structure for host-pods volume, ensure that the host-pods volume corresponds to the pods subdirectory of the kubelet root directory")
 	}
 
 	return nil

--- a/pkg/cmd/cli/restic/server_test.go
+++ b/pkg/cmd/cli/restic/server_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package restic
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/heptio/velero/pkg/test"
+)
+
+func Test_validatePodVolumesHostPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		pods    []*corev1.Pod
+		dirs    []string
+		wantErr bool
+	}{
+		{
+			name: "no error when pod volumes are present",
+			pods: []*corev1.Pod{
+				test.NewPod("foo", "bar", test.WithUID("foo")),
+				test.NewPod("zoo", "raz", test.WithUID("zoo")),
+			},
+			dirs:    []string{"foo", "zoo"},
+			wantErr: false,
+		},
+		{
+			name: "no error when pod volumes are present and there are mirror pods",
+			pods: []*corev1.Pod{
+				test.NewPod("foo", "bar", test.WithUID("foo")),
+				test.NewPod("zoo", "raz", test.WithUID("zoo"), test.WithAnnotations(v1.MirrorPodAnnotationKey, "baz")),
+			},
+			dirs:    []string{"foo", "baz"},
+			wantErr: false,
+		},
+		{
+			name: "error when pod volumes missing",
+			pods: []*corev1.Pod{
+				test.NewPod("foo", "bar", test.WithUID("foo")),
+				test.NewPod("zoo", "raz", test.WithUID("zoo")),
+			},
+			dirs:    []string{"unexpected-dir"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := ioutil.TempDir("", "host_pods")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			for _, dir := range tt.dirs {
+				err := os.Mkdir(filepath.Join(tmpDir, dir), os.ModePerm)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			kubeClient := fake.NewSimpleClientset()
+			for _, pod := range tt.pods {
+				_, err := kubeClient.CoreV1().Pods(pod.GetNamespace()).Create(pod)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			err = validatePodVolumesHostPath(kubeClient, tmpDir)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/cli/restic/server_test.go
+++ b/pkg/cmd/cli/restic/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 the Velero contributors.
+Copyright 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cmd/cli/restic/server_test.go
+++ b/pkg/cmd/cli/restic/server_test.go
@@ -55,12 +55,21 @@ func Test_validatePodVolumesHostPath(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "error when pod volumes missing",
+			name: "error when all pod volumes missing",
 			pods: []*corev1.Pod{
 				test.NewPod("foo", "bar", test.WithUID("foo")),
 				test.NewPod("zoo", "raz", test.WithUID("zoo")),
 			},
 			dirs:    []string{"unexpected-dir"},
+			wantErr: true,
+		},
+		{
+			name: "error when some pod volumes missing",
+			pods: []*corev1.Pod{
+				test.NewPod("foo", "bar", test.WithUID("foo")),
+				test.NewPod("zoo", "raz", test.WithUID("zoo")),
+			},
+			dirs:    []string{"foo"},
 			wantErr: true,
 		},
 	}

--- a/pkg/cmd/cli/restic/server_test.go
+++ b/pkg/cmd/cli/restic/server_test.go
@@ -85,6 +85,7 @@ func Test_validatePodVolumesHostPath(t *testing.T) {
 
 			s := &resticServer{
 				kubeClient: kubeClient,
+				logger:     testutil.NewLogger(),
 				fileSystem: fs,
 			}
 

--- a/pkg/test/resources.go
+++ b/pkg/test/resources.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // APIResource stores information about a specific Kubernetes API
@@ -318,6 +319,13 @@ func WithFinalizers(vals ...string) func(obj metav1.Object) {
 func WithDeletionTimestamp(val time.Time) func(obj metav1.Object) {
 	return func(obj metav1.Object) {
 		obj.SetDeletionTimestamp(&metav1.Time{Time: val})
+	}
+}
+
+// WithUID is a functional option that applies the specified UID to an object.
+func WithUID(val string) func(obj metav1.Object) {
+	return func(obj metav1.Object) {
+		obj.SetUID(types.UID(val))
 	}
 }
 


### PR DESCRIPTION
Adds validation to check if the pod volumes hostpath mount contains directories for the pods on this node.

fixes #1557 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>