### PR TITLE
add restore item action to change PVC/PV storage class name

### DIFF
--- a/changelogs/unreleased/1621-skriss
+++ b/changelogs/unreleased/1621-skriss
@@ -1,0 +1,1 @@
+add plugin for updating PV & PVC storage classes on restore based on a config map

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -163,6 +163,10 @@ func newChangeStorageClassRestoreItemAction(f client.Factory) veleroplugin.Handl
 			return nil, err
 		}
 
-		return restore.NewChangeStorageClassAction(logger, client.CoreV1().ConfigMaps(f.Namespace())), nil
+		return restore.NewChangeStorageClassAction(
+			logger,
+			client.CoreV1().ConfigMaps(f.Namespace()),
+			client.StorageV1().StorageClasses(),
+		), nil
 	}
 }

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -52,8 +52,8 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/serviceaccount", newServiceAccountRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/addPVCFromPod", newAddPVCFromPodRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/addPVFromPVC", newAddPVFromPVCRestoreItemAction).
+				RegisterRestoreItemAction("velero.io/add-pvc-from-pod", newAddPVCFromPodRestoreItemAction).
+				RegisterRestoreItemAction("velero.io/add-pv-from-pvc", newAddPVFromPVCRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/change-storageclass", newChangeStorageClassRestoreItemAction(f)).
 				Serve()
 		},

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -54,6 +54,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterRestoreItemAction("velero.io/serviceaccount", newServiceAccountRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/addPVCFromPod", newAddPVCFromPodRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/addPVFromPVC", newAddPVFromPVCRestoreItemAction).
+				RegisterRestoreItemAction("velero.io/change-storageclass", newChangeStorageClassRestoreItemAction(f)).
 				Serve()
 		},
 	}
@@ -153,4 +154,15 @@ func newAddPVCFromPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, 
 
 func newAddPVFromPVCRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	return restore.NewAddPVFromPVCAction(logger), nil
+}
+
+func newChangeStorageClassRestoreItemAction(f client.Factory) veleroplugin.HandlerInitializer {
+	return func(logger logrus.FieldLogger) (interface{}, error) {
+		client, err := f.KubeClient()
+		if err != nil {
+			return nil, err
+		}
+
+		return restore.NewChangeStorageClassAction(logger, client.CoreV1().ConfigMaps(f.Namespace())), nil
+	}
 }

--- a/pkg/cmd/server/plugin/plugin.go
+++ b/pkg/cmd/server/plugin/plugin.go
@@ -46,15 +46,15 @@ func NewCommand(f client.Factory) *cobra.Command {
 				RegisterVolumeSnapshotter("velero.io/gcp", newGcpVolumeSnapshotter).
 				RegisterBackupItemAction("velero.io/pv", newPVBackupItemAction).
 				RegisterBackupItemAction("velero.io/pod", newPodBackupItemAction).
-				RegisterBackupItemAction("velero.io/serviceaccount", newServiceAccountBackupItemAction(f)).
+				RegisterBackupItemAction("velero.io/service-account", newServiceAccountBackupItemAction(f)).
 				RegisterRestoreItemAction("velero.io/job", newJobRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/pod", newPodRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/restic", newResticRestoreItemAction(f)).
 				RegisterRestoreItemAction("velero.io/service", newServiceRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/serviceaccount", newServiceAccountRestoreItemAction).
+				RegisterRestoreItemAction("velero.io/service-account", newServiceAccountRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/add-pvc-from-pod", newAddPVCFromPodRestoreItemAction).
 				RegisterRestoreItemAction("velero.io/add-pv-from-pvc", newAddPVFromPVCRestoreItemAction).
-				RegisterRestoreItemAction("velero.io/change-storageclass", newChangeStorageClassRestoreItemAction(f)).
+				RegisterRestoreItemAction("velero.io/change-storage-class", newChangeStorageClassRestoreItemAction(f)).
 				Serve()
 		},
 	}

--- a/pkg/restore/change_storageclass_action.go
+++ b/pkg/restore/change_storageclass_action.go
@@ -64,7 +64,7 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 	defer a.logger.Info("Done executing ChangeStorageClassAction")
 
 	a.logger.Debug("Getting plugin config")
-	config, err := getPluginConfig(framework.PluginKindRestoreItemAction, "velero.io/change-storageclass", a.configMapClient)
+	config, err := getPluginConfig(framework.PluginKindRestoreItemAction, "velero.io/change-storage-class", a.configMapClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restore/change_storageclass_action.go
+++ b/pkg/restore/change_storageclass_action.go
@@ -58,9 +58,7 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 
 	if config == nil || len(config.Data) == 0 {
 		a.logger.Debug("No storage class mappings found")
-		return &velero.RestoreItemActionExecuteOutput{
-			UpdatedItem: input.Item,
-		}, nil
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 
 	obj, ok := input.Item.(*unstructured.Unstructured)
@@ -82,16 +80,12 @@ func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecut
 	}
 	if storageClass == "" {
 		log.Debug("Item has no storage class specified")
-		return &velero.RestoreItemActionExecuteOutput{
-			UpdatedItem: input.Item,
-		}, nil
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 
 	newStorageClass, ok := config.Data[storageClass]
 	if !ok {
-		return &velero.RestoreItemActionExecuteOutput{
-			UpdatedItem: input.Item,
-		}, nil
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}
 
 	log.Infof("Updating item's storage class name to %s", newStorageClass)

--- a/pkg/restore/change_storageclass_action.go
+++ b/pkg/restore/change_storageclass_action.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1apiclient "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/heptio/velero/pkg/plugin/framework"
+	"github.com/heptio/velero/pkg/plugin/velero"
+)
+
+// ChangeStorageClassAction updates a PV or PVC's storage class name
+// if a mapping is found in the plugin's config map.
+type ChangeStorageClassAction struct {
+	logger logrus.FieldLogger
+	client corev1apiclient.ConfigMapInterface
+}
+
+func NewChangeStorageClassAction(logger logrus.FieldLogger, client corev1apiclient.ConfigMapInterface) *ChangeStorageClassAction {
+	return &ChangeStorageClassAction{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a *ChangeStorageClassAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"persistentvolumeclaims", "persistentvolumes"},
+	}, nil
+}
+
+func (a *ChangeStorageClassAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	a.logger.Info("Executing ChangeStorageClassAction")
+	defer a.logger.Info("Done executing ChangeStorageClassAction")
+
+	a.logger.Debug("Getting plugin config")
+	config, err := getPluginConfig(framework.PluginKindRestoreItemAction, "velero.io/change-storageclass", a.client)
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil || len(config.Data) == 0 {
+		a.logger.Debug("No storage class mappings found")
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem: input.Item,
+		}, nil
+	}
+
+	obj, ok := input.Item.(*unstructured.Unstructured)
+	if !ok {
+		return nil, errors.Errorf("object was of unexpected type %T", input.Item)
+	}
+
+	log := a.logger.WithFields(map[string]interface{}{
+		"kind":      obj.GetKind(),
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	// use the unstructured helpers here since this code is for both PVs and PVCs, and the
+	// field names are the same for both types.
+	storageClass, _, err := unstructured.NestedString(obj.UnstructuredContent(), "spec", "storageClassName")
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting item's spec.storageClassName")
+	}
+	if storageClass == "" {
+		log.Debug("Item has no storage class specified")
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem: input.Item,
+		}, nil
+	}
+
+	newStorageClass, ok := config.Data[storageClass]
+	if !ok {
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem: input.Item,
+		}, nil
+	}
+
+	log.Infof("Updating item's storage class name to %s", newStorageClass)
+
+	if err := unstructured.SetNestedField(obj.UnstructuredContent(), newStorageClass, "spec", "storageClassName"); err != nil {
+		return nil, errors.Wrap(err, "unable to set item's spec.storageClassName")
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(obj), nil
+}

--- a/pkg/restore/change_storageclass_action_test.go
+++ b/pkg/restore/change_storageclass_action_test.go
@@ -68,10 +68,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -99,10 +99,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -130,7 +130,7 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
 						"velero.io/plugin-config":     "true",
 						"velero.io/some-other-plugin": "RestoreItemAction",
@@ -161,10 +161,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{},
@@ -187,10 +187,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -212,10 +212,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -240,10 +240,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -271,10 +271,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -302,10 +302,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{
@@ -328,10 +328,10 @@ func TestChangeStorageClassActionExecute(t *testing.T) {
 			configMap: &corev1api.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "velero",
-					Name:      "change-storageclass",
+					Name:      "change-storage-class",
 					Labels: map[string]string{
-						"velero.io/plugin-config":       "true",
-						"velero.io/change-storageclass": "RestoreItemAction",
+						"velero.io/plugin-config":        "true",
+						"velero.io/change-storage-class": "RestoreItemAction",
 					},
 				},
 				Data: map[string]string{

--- a/pkg/restore/change_storageclass_action_test.go
+++ b/pkg/restore/change_storageclass_action_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restore
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/heptio/velero/pkg/plugin/velero"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1api "k8s.io/api/core/v1"
+	storagev1api "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestChangeStorageClassActionExecute runs the ChangeStorageClassAction's Execute
+// method and validates that the item's storage class is modified (or not) as expected.
+// Validation is done by comparing the result of the Execute method to the test case's
+// desired result.
+func TestChangeStorageClassActionExecute(t *testing.T) {
+	objectMeta := func(ns, name string) metav1.ObjectMeta {
+		return metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		}
+	}
+
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	tests := []struct {
+		name         string
+		pvOrPVC      interface{}
+		configMap    *corev1api.ConfigMap
+		storageClass *storagev1api.StorageClass
+		want         interface{}
+		wantErr      error
+	}{
+		{
+			name: "a valid mapping for a persistent volume is applied correctly",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "storageclass-2",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-2",
+				},
+			},
+		},
+		{
+			name: "a valid mapping for a persistent volume claim is applied correctly",
+			pvOrPVC: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pvc-1"),
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("storageclass-1"),
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "storageclass-2",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pvc-1"),
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("storageclass-2"),
+				},
+			},
+		},
+		{
+			name: "when no config map exists for the plugin, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":     "true",
+						"velero.io/some-other-plugin": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "storageclass-2",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+		},
+		{
+			name: "when no storage class mappings exist in the plugin config map, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+		},
+		{
+			name: "when persistent volume has no storage class, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "storageclass-2",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+			},
+		},
+		{
+			name: "when persistent volume claim has no storage class, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pvc-1"),
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "storageclass-2",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pvc-1"),
+			},
+		},
+		{
+			name: "when persistent volume's storage class has no mapping in the config map, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-3": "storageclass-4",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+		},
+		{
+			name: "when persistent volume claim's storage class has no mapping in the config map, the item is returned as-is",
+			pvOrPVC: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("storageclass-1"),
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-3": "storageclass-4",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			want: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("storageclass-1"),
+				},
+			},
+		},
+		{
+			name: "when persistent volume's storage class is mapped to a nonexistent storage class, an error is returned",
+			pvOrPVC: &corev1api.PersistentVolume{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeSpec{
+					StorageClassName: "storageclass-1",
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "nonexistent-storage-class",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			wantErr: errors.New("error getting storage class nonexistent-storage-class from API: storageclasses.storage.k8s.io \"nonexistent-storage-class\" not found"),
+		},
+		{
+			name: "when persistent volume claim's storage class is mapped to a nonexistent storage class, an error is returned",
+			pvOrPVC: &corev1api.PersistentVolumeClaim{
+				ObjectMeta: objectMeta("velero", "pv-1"),
+				Spec: corev1api.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("storageclass-1"),
+				},
+			},
+			configMap: &corev1api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "velero",
+					Name:      "change-storageclass",
+					Labels: map[string]string{
+						"velero.io/plugin-config":       "true",
+						"velero.io/change-storageclass": "RestoreItemAction",
+					},
+				},
+				Data: map[string]string{
+					"storageclass-1": "nonexistent-storage-class",
+				},
+			},
+			storageClass: &storagev1api.StorageClass{
+				ObjectMeta: objectMeta("", "storageclass-2"),
+			},
+			wantErr: errors.New("error getting storage class nonexistent-storage-class from API: storageclasses.storage.k8s.io \"nonexistent-storage-class\" not found"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			a := NewChangeStorageClassAction(
+				logrus.StandardLogger(),
+				clientset.CoreV1().ConfigMaps("velero"),
+				clientset.StorageV1().StorageClasses(),
+			)
+
+			// set up test data
+			if tc.configMap != nil {
+				_, err := clientset.CoreV1().ConfigMaps(tc.configMap.Namespace).Create(tc.configMap)
+				require.NoError(t, err)
+			}
+
+			if tc.storageClass != nil {
+				_, err := clientset.StorageV1().StorageClasses().Create(tc.storageClass)
+				require.NoError(t, err)
+			}
+
+			unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.pvOrPVC)
+			require.NoError(t, err)
+
+			input := &velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: unstructuredMap,
+				},
+			}
+
+			// execute method under test
+			res, err := a.Execute(input)
+
+			// validate for both error and non-error cases
+			switch {
+			case tc.wantErr != nil:
+				assert.EqualError(t, err, tc.wantErr.Error())
+			default:
+				assert.NoError(t, err)
+
+				wantUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.want)
+				require.NoError(t, err)
+
+				assert.Equal(t, &unstructured.Unstructured{Object: wantUnstructured}, res.UpdatedItem)
+			}
+		})
+	}
+}

--- a/pkg/restore/change_storageclass_action_test.go
+++ b/pkg/restore/change_storageclass_action_test.go
@@ -19,9 +19,6 @@ package restore
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/heptio/velero/pkg/plugin/velero"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -29,8 +26,11 @@ import (
 	corev1api "k8s.io/api/core/v1"
 	storagev1api "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/heptio/velero/pkg/plugin/velero"
 )
 
 // TestChangeStorageClassActionExecute runs the ChangeStorageClassAction's Execute


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #595 

Since we've been hearing regular demand for this, I put together a plugin that can update a PV or PVC's storage class. It fetches old->new storage class mappings from a configmap, and it's a no-op if that configmap does not exist or is empty.  I thought about making this an out-of-tree plugin, but I didn't really see any reason not to keep it in-tree given that it's a no-op if the corresponding ConfigMap doesn't exist. Interested in your thoughts here.

Working on adding unit tests, but wanted to get input on approach first.

cc @nrb @carlisia @prydonius