### PR TITLE
openshift needs namespace annotation for restic to schedule on all nodes

### DIFF
--- a/site/docs/master/restic.md
+++ b/site/docs/master/restic.md
@@ -83,13 +83,14 @@ If restic is not running in a privileged mode, it will not be able to access pod
 By default a userland openshift namespace will not schedule pods on all nodes in the cluster.
 To schedule on all nodes the namespace needs an annotation:
 ```
-oc annotate namespace < velero namespace > openshift.io/node-selector=""
+oc annotate namespace <velero namespace> openshift.io/node-selector=""
 ```
-This should be done before valero installation the ds needs to be deleted and recreated:
+This should be done before velero installation.
+Or the ds needs to be deleted and recreated:
 ```
-oc get ds restic -o yaml > ds.yaml
-# Now add the annotation
-oc create -f ds.yaml
+oc get ds restic -o yaml -n <velero namespace> > ds.yaml
+oc annotate namespace <velero namespace> openshift.io/node-selector=""
+oc create -n <velero namespace> -f ds.yaml
 ```
 
 **Enterprise PKS**

--- a/site/docs/master/restic.md
+++ b/site/docs/master/restic.md
@@ -80,6 +80,18 @@ $ oc adm policy add-scc-to-user privileged -z velero -n velero
 
 If restic is not running in a privileged mode, it will not be able to access pods volumes within the mounted hostpath directory because of the default enforced SELinux mode configured in the host system level. You can [create a custom SCC](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html) in order to relax the security in your cluster so that restic pods are allowed to use the hostPath volume plug-in without granting them access to the `privileged` SCC.
 
+By default a userland openshift namespace will not schedule pods on all nodes in the cluster.
+To schedule on all nodes the namespace needs an annotation:
+```
+oc annotate namespace < velero namespace > openshift.io/node-selector=""
+```
+This should be done before valero installation the ds needs to be deleted and recreated:
+```
+oc get ds restic -o yaml > ds.yaml
+# Now add the annotation
+oc create -f ds.yaml
+```
+
 **Enterprise PKS**
 
 You need to enable the `Allow Privileged` option in your plan configuration so that restic is able to mount the hostpath.


### PR DESCRIPTION
This is just a useful hint in the docs for all openshift users.
The restic pods will schedule only on the app nodes without the annotation.
