### PR TITLE
bug fix: Fixed namespace usage with cli command 'version'

### DIFF
--- a/changelogs/unreleased/1630-jwmatthews
+++ b/changelogs/unreleased/1630-jwmatthews
@@ -1,0 +1,1 @@
+bug fix: Fixed namespace usage with cli command 'version'

--- a/pkg/cmd/cli/version/version.go
+++ b/pkg/cmd/cli/version/version.go
@@ -50,7 +50,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 
 				veleroClient = client.VeleroV1()
 			}
-
+			serverStatusGetter.Namespace = f.Namespace()
 			printVersion(os.Stdout, clientOnly, veleroClient, serverStatusGetter)
 		},
 	}


### PR DESCRIPTION
Signed-off-by: John Matthews <jwmatthews@gmail.com>

Noticed today that `velero version -n NAMESPACE` was not honoring the specified namespace.

```
$ velero version -n mig
Client:
	Version: v1.0.0
	Git commit: 72f5cadc3a865019ab9dc043d4952c9bfd5f2ecb
<error getting server version: namespaces "velero" not found>

```

Issue is that while -n/--namespace will set the namespace, the instance of DefaultServerStatusGetter is using the initial namespace value before the flags have been parsed, so it's using the default version. 


https://github.com/heptio/velero/blob/master/pkg/cmd/cli/version/version.go#L34
```
func NewCommand(f client.Factory) *cobra.Command {
	clientOnly := false
	serverStatusGetter := &serverstatus.DefaultServerStatusGetter{
		Namespace: f.Namespace(),
		Timeout:   5 * time.Second,
	}

	c := &cobra.Command{
		Use:   "version",
		Short: "Print the velero version and associated image",
		Run: func(c *cobra.Command, args []string) {
			var veleroClient velerov1client.ServerStatusRequestsGetter

			if !clientOnly {
				client, err := f.Client()
				cmd.CheckError(err)

				veleroClient = client.VeleroV1()
			}

			printVersion(os.Stdout, clientOnly, veleroClient, serverStatusGetter)
		},
	}

```

https://github.com/heptio/velero/blob/master/pkg/client/factory.go#L70
`f.flags.StringVarP(&f.namespace, "namespace", "n", f.namespace, "The namespace in which Velero should operate")`

https://github.com/heptio/velero/blob/master/pkg/client/factory.go#L106
```
func (f *factory) Namespace() string {
	return f.namespace
}
```


The change I'm suggesting is to ensure the namespace value is set on the serverStatusGetter when the command is run, this way flags have been parsed.


Below is an example of running it with change, now it's going to the correct namespace.
I'm using a custom built velero image for the below, hence the version string itself is not set, but the mechanism is working as expected now.
```

$ ./velero version -n mig
Client:
	Version: master
	Git commit: f829dabcf4469685343a97ec51042d8a641b58bb-dirty
Server:
	Version: 


$ oc get serverstatusrequests velero-cli-qx469 -o yaml
apiVersion: velero.io/v1
kind: ServerStatusRequest
metadata:
  creationTimestamp: "2019-07-07T17:35:10Z"
  generateName: velero-cli-
  generation: 2
  name: velero-cli-qx469
  namespace: mig
  resourceVersion: "458795"
  selfLink: /apis/velero.io/v1/namespaces/mig/serverstatusrequests/velero-cli-qx469
  uid: 91a70b3a-a0dd-11e9-be40-02591404d96a
spec: {}
status:
  phase: Processed
  plugins: null
  processedTimestamp: "2019-07-07T17:35:10Z"
  serverVersion: ""

```
