### PR TITLE
omit storageClassName in nginx example to use default StorageClass

### DIFF
--- a/examples/nginx-app/with-pv.yaml
+++ b/examples/nginx-app/with-pv.yaml
@@ -29,7 +29,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  storageClassName: <YOUR_STORAGE_CLASS_NAME>
+  # storageClassName: <YOUR_STORAGE_CLASS_NAME>
   accessModes:
     - ReadWriteOnce
   resources:

--- a/site/docs/master/aws-config.md
+++ b/site/docs/master/aws-config.md
@@ -303,12 +303,6 @@ It can be set up for Velero by creating a role that will have required permissio
     ...
     ```
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `gp2`. This is AWS's default `StorageClass` name.
-
 [0]: namespace.md
 [5]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
 [6]: api-types/volumesnapshotlocation.md#aws

--- a/site/docs/master/azure-config.md
+++ b/site/docs/master/azure-config.md
@@ -166,12 +166,6 @@ Additionally, you can specify `--use-restic` to enable restic support, and `--wa
 
 For more complex installation needs, use either the Helm chart, or add `--dry-run -o yaml` options for generating the YAML representation for the installation.
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `default`. This is Azure's default `StorageClass` name.
-
 [0]: namespace.md
 [8]: api-types/volumesnapshotlocation.md#azure
 [17]: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects

--- a/site/docs/master/gcp-config.md
+++ b/site/docs/master/gcp-config.md
@@ -134,13 +134,6 @@ Additionally, you can specify `--use-restic` to enable restic support, and `--wa
 
 For more complex installation needs, use either the Helm chart, or add `--dry-run -o yaml` options for generating the YAML representation for the installation.
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `standard`. This is GCP's default `StorageClass` name.
-
-
 [0]: namespace.md
 [7]: api-types/backupstoragelocation.md#gcp
 [8]: api-types/volumesnapshotlocation.md#gcp

--- a/site/docs/master/ibm-config.md
+++ b/site/docs/master/ibm-config.md
@@ -82,8 +82,7 @@ For more complex installation needs, use either the Helm chart, or add `--dry-ru
 
 If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
 
-Replace `<YOUR_STORAGE_CLASS_NAME>` with your `StorageClass` name.
-
+Uncomment `storageClassName: <YOUR_STORAGE_CLASS_NAME>` and replace with your `StorageClass` name.
 
 [0]: namespace.md
 [1]: https://console.bluemix.net/docs/services/cloud-object-storage/basics/order-storage.html#creating-a-new-resource-instance

--- a/site/docs/v1.0.0/aws-config.md
+++ b/site/docs/v1.0.0/aws-config.md
@@ -303,12 +303,6 @@ It can be set up for Velero by creating a role that will have required permissio
     ...
     ```
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `gp2`. This is AWS's default `StorageClass` name.
-
 [0]: namespace.md
 [5]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
 [6]: api-types/volumesnapshotlocation.md#aws

--- a/site/docs/v1.0.0/azure-config.md
+++ b/site/docs/v1.0.0/azure-config.md
@@ -166,12 +166,6 @@ Additionally, you can specify `--use-restic` to enable restic support, and `--wa
 
 For more complex installation needs, use either the Helm chart, or add `--dry-run -o yaml` options for generating the YAML representation for the installation.
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `default`. This is Azure's default `StorageClass` name.
-
 [0]: namespace.md
 [8]: api-types/volumesnapshotlocation.md#azure
 [17]: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-application-objects

--- a/site/docs/v1.0.0/gcp-config.md
+++ b/site/docs/v1.0.0/gcp-config.md
@@ -134,13 +134,6 @@ Additionally, you can specify `--use-restic` to enable restic support, and `--wa
 
 For more complex installation needs, use either the Helm chart, or add `--dry-run -o yaml` options for generating the YAML representation for the installation.
 
-## Installing the nginx example (optional)
-
-If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
-
-Replace `<YOUR_STORAGE_CLASS_NAME>` with `standard`. This is GCP's default `StorageClass` name.
-
-
 [0]: namespace.md
 [7]: api-types/backupstoragelocation.md#gcp
 [8]: api-types/volumesnapshotlocation.md#gcp

--- a/site/docs/v1.0.0/ibm-config.md
+++ b/site/docs/v1.0.0/ibm-config.md
@@ -82,7 +82,7 @@ For more complex installation needs, use either the Helm chart, or add `--dry-ru
 
 If you run the nginx example, in file `examples/nginx-app/with-pv.yaml`:
 
-Replace `<YOUR_STORAGE_CLASS_NAME>` with your `StorageClass` name.
+Uncomment `storageClassName: <YOUR_STORAGE_CLASS_NAME>` and replace with your `StorageClass` name.
 
 
 [0]: namespace.md


### PR DESCRIPTION
Use the default StorageClass in the cluster where possible, leave `storageClassName` field commented out so it can easily be modified in the case where the user needs to manually set it.

Most providers will have a default StorageClass, so it seems easier to keep it commented out by default.

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>