### PR TITLE
Remove references to apps/v1beta1 API group

### DIFF
--- a/changelogs/unreleased/1673-nrb
+++ b/changelogs/unreleased/1673-nrb
@@ -1,1 +1,1 @@
-Update Velero Deployment to use apps/v1 API group
+Update Velero Deployment to use apps/v1 API group. `velero install` and `velero plugin add/remove` commands will now require Kubernetes 1.9+

--- a/changelogs/unreleased/1673-nrb
+++ b/changelogs/unreleased/1673-nrb
@@ -1,0 +1,1 @@
+Update Velero Deployment to use apps/v1 API group

--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   name: velero
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: velero

--- a/examples/nginx-app/base.yaml
+++ b/examples/nginx-app/base.yaml
@@ -21,7 +21,7 @@ metadata:
     app: nginx
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/examples/nginx-app/with-pv.yaml
+++ b/examples/nginx-app/with-pv.yaml
@@ -37,7 +37,7 @@ spec:
       storage: 50Mi
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/pkg/cmd/cli/plugin/add.go
+++ b/pkg/cmd/cli/plugin/add.go
@@ -55,7 +55,7 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 				cmd.CheckError(err)
 			}
 
-			veleroDeploy, err := kubeClient.AppsV1beta1().Deployments(f.Namespace()).Get(veleroDeployment, metav1.GetOptions{})
+			veleroDeploy, err := kubeClient.AppsV1().Deployments(f.Namespace()).Get(veleroDeployment, metav1.GetOptions{})
 			if err != nil {
 				cmd.CheckError(err)
 			}
@@ -125,7 +125,7 @@ func NewAddCommand(f client.Factory) *cobra.Command {
 			patchBytes, err := jsonpatch.CreateMergePatch(original, updated)
 			cmd.CheckError(err)
 
-			_, err = kubeClient.AppsV1beta1().Deployments(veleroDeploy.Namespace).Patch(veleroDeploy.Name, types.MergePatchType, patchBytes)
+			_, err = kubeClient.AppsV1().Deployments(veleroDeploy.Namespace).Patch(veleroDeploy.Name, types.MergePatchType, patchBytes)
 			cmd.CheckError(err)
 		},
 	}

--- a/pkg/cmd/cli/plugin/remove.go
+++ b/pkg/cmd/cli/plugin/remove.go
@@ -40,7 +40,7 @@ func NewRemoveCommand(f client.Factory) *cobra.Command {
 				cmd.CheckError(err)
 			}
 
-			veleroDeploy, err := kubeClient.AppsV1beta1().Deployments(f.Namespace()).Get(veleroDeployment, metav1.GetOptions{})
+			veleroDeploy, err := kubeClient.AppsV1().Deployments(f.Namespace()).Get(veleroDeployment, metav1.GetOptions{})
 			if err != nil {
 				cmd.CheckError(err)
 			}
@@ -72,7 +72,7 @@ func NewRemoveCommand(f client.Factory) *cobra.Command {
 			patchBytes, err := jsonpatch.CreateMergePatch(original, updated)
 			cmd.CheckError(err)
 
-			_, err = kubeClient.AppsV1beta1().Deployments(veleroDeploy.Namespace).Patch(veleroDeploy.Name, types.MergePatchType, patchBytes)
+			_, err = kubeClient.AppsV1().Deployments(veleroDeploy.Namespace).Patch(veleroDeploy.Name, types.MergePatchType, patchBytes)
 			cmd.CheckError(err)
 		},
 	}

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -19,7 +19,7 @@ package install
 import (
 	"strings"
 
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -74,7 +74,7 @@ func WithRestoreOnly() podTemplateOption {
 	}
 }
 
-func Deployment(namespace string, opts ...podTemplateOption) *appsv1beta1.Deployment {
+func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment {
 	// TODO: Add support for server args
 	c := &podTemplateConfig{
 		image: DefaultImage,
@@ -94,13 +94,13 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1beta1.Deploy
 	containerLabels := labels()
 	containerLabels["deploy"] = "velero"
 
-	deployment := &appsv1beta1.Deployment{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: objectMeta(namespace, "velero"),
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
-			APIVersion: appsv1beta1.SchemeGroupVersion.String(),
+			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
-		Spec: appsv1beta1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"deploy": "velero"}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -120,11 +120,11 @@ func crdsAreReady(factory client.DynamicFactory, crdKinds []string) (bool, error
 	return areReady, nil
 }
 
-func isAvailable(c appsv1beta1.DeploymentCondition) bool {
+func isAvailable(c appsv1.DeploymentCondition) bool {
 	// Make sure that the deployment has been available for at least 10 seconds.
 	// This is because the deployment can show as Ready momentarily before the pods fall into a CrashLoopBackOff.
 	// See podutils.IsPodAvailable upstream for similar logic with pods
-	if c.Type == appsv1beta1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+	if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
 		if !c.LastTransitionTime.IsZero() && c.LastTransitionTime.Add(10*time.Second).Before(time.Now()) {
 			return true
 		}
@@ -134,7 +134,7 @@ func isAvailable(c appsv1beta1.DeploymentCondition) bool {
 
 // DeploymentIsReady will poll the kubernetes API server to see if the velero deployment is ready to service user requests.
 func DeploymentIsReady(factory client.DynamicFactory, namespace string) (bool, error) {
-	gvk := schema.FromAPIVersionAndKind(appsv1beta1.SchemeGroupVersion.String(), "Deployment")
+	gvk := schema.FromAPIVersionAndKind(appsv1.SchemeGroupVersion.String(), "Deployment")
 	apiResource := metav1.APIResource{
 		Name:       "deployments",
 		Namespaced: true,
@@ -154,7 +154,7 @@ func DeploymentIsReady(factory client.DynamicFactory, namespace string) (bool, e
 			return false, errors.Wrap(err, "error waiting for deployment to be ready")
 		}
 
-		deploy := new(appsv1beta1.Deployment)
+		deploy := new(appsv1.Deployment)
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredDeployment.Object, deploy); err != nil {
 			return false, errors.Wrap(err, "error converting deployment from unstructured")
 		}


### PR DESCRIPTION
In Kubernetes v1.16, the apps/v1 API group will be the default served
for relevant resources.

Update any references to apps/v1beta1 for fowards compatibility.

Fixes #1672

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>