### PR TITLE
fix Deployments in examples for apps/v1 selector requirement

### DIFF
--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -29,6 +29,9 @@ metadata:
 spec:
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      component: minio
   template:
     metadata:
       labels:

--- a/examples/nginx-app/base.yaml
+++ b/examples/nginx-app/base.yaml
@@ -28,6 +28,9 @@ metadata:
   namespace: nginx-example
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/examples/nginx-app/with-pv.yaml
+++ b/examples/nginx-app/with-pv.yaml
@@ -44,6 +44,9 @@ metadata:
   namespace: nginx-example
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:


### PR DESCRIPTION
The apps/v1 API makes the selector in Deployments a required property.

```
error: error validating "examples/nginx-app/base.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>