### PR TITLE
Fixes documentation about aws region.

### DIFF
--- a/site/docs/master/api-types/volumesnapshotlocation.md
+++ b/site/docs/master/api-types/volumesnapshotlocation.md
@@ -40,7 +40,7 @@ The configurable parameters are as follows:
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
+| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Required. |
 | `profile` | string | "default" | AWS profile within the credential file to use for given store |
 
 #### Azure

--- a/site/docs/v1.0.0/api-types/volumesnapshotlocation.md
+++ b/site/docs/v1.0.0/api-types/volumesnapshotlocation.md
@@ -39,7 +39,7 @@ The configurable parameters are as follows:
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Queried from the AWS S3 API if not provided. |
+| `region` | string | Empty | *Example*: "us-east-1"<br><br>See [AWS documentation][3] for the full list.<br><br>Required. |
 
 #### Azure
 


### PR DESCRIPTION
[Reading the code](https://github.com/heptio/velero/blob/master/pkg/cloudprovider/aws/volume_snapshotter.go#L75-L79), you understand that this sentence is misleading.