### PR TITLE
fix typo in schedule create example

### DIFF
--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -61,7 +61,7 @@ example: "@every 2h30m".`,
 	velero create schedule NAME --schedule="@every 24h" --include-namespaces web
 
 	# Create a weekly backup, each living for 90 days (2160 hours)
-	velero create schedule NAME --schedules="@every 168h" --ttl 2160h0m0s
+	velero create schedule NAME --schedule="@every 168h" --ttl 2160h0m0s
 	`,
 		Args: cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #1650 