### PR TITLE
Enable Jekyll incremental rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ serve-docs:
 	-v "$$(pwd)/site:/srv/jekyll" \
 	-it -p 4000:4000 \
 	jekyll/jekyll \
-	jekyll serve --livereload
+	jekyll serve --livereload --incremental
 
 # gen-docs generates a new versioned docs directory under site/docs. It follows
 # the following process:

--- a/site/README-JEKYLL.md
+++ b/site/README-JEKYLL.md
@@ -27,7 +27,7 @@ This mirrors the plug-ins used by GitHub Pages on your local machine including J
 3. `cd velero/site`
 4. `rbenv local 2.6.3`
 5. `bundle install`
-6. Serve the site and watch for markup/sass changes `jekyll serve --livereload`. You may need to run `bundle exec jekyll serve --livereload`.
+6. Serve the site and watch for markup/sass changes `jekyll serve --livereload --incremental`. You may need to run `bundle exec jekyll serve --livereload --incremental`.
 7. View your website at http://127.0.0.1:4000/
 8. Commit any changes and push everything to your fork.
 9. Once you're ready, submit a PR of your changes. Netlify will automatically generate a preview of your changes.


### PR DESCRIPTION
Without the incremental switch, live rebuilds were taking 20s (on a
Linux host) for a single-line change. With the switch, they dropped to
8s.

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>