### PR TITLE
Properly restore PVs with a reclaim policy of Retain and restic backups

### DIFF
--- a/changelogs/unreleased/1713-skriss
+++ b/changelogs/unreleased/1713-skriss
@@ -1,0 +1,1 @@
+properly restore PVs backed up with restic and a reclaim policy of "Retain"

--- a/pkg/restic/backupper.go
+++ b/pkg/restic/backupper.go
@@ -150,7 +150,7 @@ func (b *backupper) BackupPodVolumes(backup *velerov1api.Backup, pod *corev1api.
 			continue
 		}
 
-		volumeBackup := newPodVolumeBackup(backup, pod, volumeName, repo.Spec.ResticIdentifier)
+		volumeBackup := newPodVolumeBackup(backup, pod, volume, repo.Spec.ResticIdentifier)
 		numVolumeSnapshots++
 		if volumeBackup, err = b.repoManager.veleroClient.VeleroV1().PodVolumeBackups(volumeBackup.Namespace).Create(volumeBackup); err != nil {
 			errs = append(errs, err)
@@ -221,8 +221,8 @@ func isHostPathVolume(volume *corev1api.Volume, pvcGetter pvcGetter, pvGetter pv
 	return pv.Spec.HostPath != nil, nil
 }
 
-func newPodVolumeBackup(backup *velerov1api.Backup, pod *corev1api.Pod, volumeName, repoIdentifier string) *velerov1api.PodVolumeBackup {
-	return &velerov1api.PodVolumeBackup{
+func newPodVolumeBackup(backup *velerov1api.Backup, pod *corev1api.Pod, volume corev1api.Volume, repoIdentifier string) *velerov1api.PodVolumeBackup {
+	pvb := &velerov1api.PodVolumeBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    backup.Namespace,
 			GenerateName: backup.Name + "-",
@@ -248,19 +248,29 @@ func newPodVolumeBackup(backup *velerov1api.Backup, pod *corev1api.Pod, volumeNa
 				Name:      pod.Name,
 				UID:       pod.UID,
 			},
-			Volume: volumeName,
+			Volume: volume.Name,
 			Tags: map[string]string{
 				"backup":     backup.Name,
 				"backup-uid": string(backup.UID),
 				"pod":        pod.Name,
 				"pod-uid":    string(pod.UID),
 				"ns":         pod.Namespace,
-				"volume":     volumeName,
+				"volume":     volume.Name,
 			},
 			BackupStorageLocation: backup.Spec.StorageLocation,
 			RepoIdentifier:        repoIdentifier,
 		},
 	}
+
+	// if the volume is for a PVC, annotate the pod volume backup with its name
+	// for easy identification as a PVC backup during restore.
+	if volume.PersistentVolumeClaim != nil {
+		pvb.SetAnnotations(map[string]string{
+			PVCNameAnnotation: volume.PersistentVolumeClaim.ClaimName,
+		})
+	}
+
+	return pvb
 }
 
 func errorOnly(_ interface{}, err error) error {

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -35,11 +35,24 @@ import (
 )
 
 const (
-	DaemonSet                   = "restic"
-	InitContainer               = "restic-wait"
+	// DaemonSet is the name of the Velero restic daemonset.
+	DaemonSet = "restic"
+
+	// InitContainer is the name of the init container added
+	// to workload pods to help with restores.
+	InitContainer = "restic-wait"
+
+	// DefaultMaintenanceFrequency is the default time interval
+	// at which restic check & prune are run.
 	DefaultMaintenanceFrequency = 24 * time.Hour
 
+	// PVCNameAnnotation is the key for the annotation added to
+	// pod volume backups when they're for a PVC.
+	PVCNameAnnotation = "velero.io/pvc-name"
+
 	// Deprecated.
+	//
+	// TODO(2.0): remove
 	podAnnotationPrefix = "snapshot.velero.io/"
 
 	volumesToBackupAnnotation = "backup.velero.io/backup-volumes"

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -1826,15 +1826,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 				},
 			},
 			volumeSnapshotLocations: []*velerov1api.VolumeSnapshotLocation{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: velerov1api.DefaultNamespace,
-						Name:      "default",
-					},
-					Spec: velerov1api.VolumeSnapshotLocationSpec{
-						Provider: "provider-1",
-					},
-				},
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "default").Provider("provider-1").Result(),
 			},
 			volumeSnapshotterGetter: map[string]velero.VolumeSnapshotter{
 				"provider-1": &volumeSnapshotter{
@@ -1883,15 +1875,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 				},
 			},
 			volumeSnapshotLocations: []*velerov1api.VolumeSnapshotLocation{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: velerov1api.DefaultNamespace,
-						Name:      "default",
-					},
-					Spec: velerov1api.VolumeSnapshotLocationSpec{
-						Provider: "provider-1",
-					},
-				},
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "default").Provider("provider-1").Result(),
 			},
 			volumeSnapshotterGetter: map[string]velero.VolumeSnapshotter{
 				"provider-1": &volumeSnapshotter{
@@ -1945,15 +1929,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 				},
 			},
 			volumeSnapshotLocations: []*velerov1api.VolumeSnapshotLocation{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: velerov1api.DefaultNamespace,
-						Name:      "default",
-					},
-					Spec: velerov1api.VolumeSnapshotLocationSpec{
-						Provider: "provider-1",
-					},
-				},
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "default").Provider("provider-1").Result(),
 			},
 			volumeSnapshotterGetter: map[string]velero.VolumeSnapshotter{
 				// the volume snapshotter fake is not configured with any snapshotID -> volumeID
@@ -2005,15 +1981,7 @@ func TestRestorePersistentVolumes(t *testing.T) {
 				},
 			},
 			volumeSnapshotLocations: []*velerov1api.VolumeSnapshotLocation{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: velerov1api.DefaultNamespace,
-						Name:      "default",
-					},
-					Spec: velerov1api.VolumeSnapshotLocationSpec{
-						Provider: "provider-1",
-					},
-				},
+				builder.ForVolumeSnapshotLocation(velerov1api.DefaultNamespace, "default").Provider("provider-1").Result(),
 			},
 			volumeSnapshotterGetter: map[string]velero.VolumeSnapshotter{
 				// the volume snapshotter fake is not configured with any snapshotID -> volumeID


### PR DESCRIPTION
Fixes #1151 
Pending #1691 being addressed.

Currently, PVs with a reclaim policy of `Retain` and a restic backup don't get restored properly. This code fixes that by enabling them to be dynamically re-provisioned (empty), and then doing a restore into them.

An annotation is used on the PodVolumeBackup that indicates if the PVB is for a PVC. During restore, this annotation is checked for, and if it exists, the PV is dynamically re-provisioned.

Note this PR doesn't actually do anything as-is yet; waiting for #1691 to be implemented to make the PVB's available during restore.