### PR TITLE
print resource list metadata in velero backup describe --details

### DIFF
--- a/pkg/apis/velero/v1/download_request.go
+++ b/pkg/apis/velero/v1/download_request.go
@@ -31,6 +31,7 @@ const (
 	DownloadTargetKindBackupLog             DownloadTargetKind = "BackupLog"
 	DownloadTargetKindBackupContents        DownloadTargetKind = "BackupContents"
 	DownloadTargetKindBackupVolumeSnapshots DownloadTargetKind = "BackupVolumeSnapshots"
+	DownloadTargetKindBackupResourceList    DownloadTargetKind = "BackupResourceList"
 	DownloadTargetKindRestoreLog            DownloadTargetKind = "RestoreLog"
 	DownloadTargetKindRestoreResults        DownloadTargetKind = "RestoreResults"
 )

--- a/pkg/cmd/util/downloadrequest/downloadrequest.go
+++ b/pkg/cmd/util/downloadrequest/downloadrequest.go
@@ -32,6 +32,10 @@ import (
 	velerov1client "github.com/heptio/velero/pkg/generated/clientset/versioned/typed/velero/v1"
 )
 
+// ErrNotFound is exported for external packages to check for when a file is
+// not found
+var ErrNotFound = errors.New("file not found")
+
 func Stream(client velerov1client.DownloadRequestsGetter, namespace, name string, kind v1.DownloadTargetKind, w io.Writer, timeout time.Duration) error {
 	req := &v1.DownloadRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +101,7 @@ Loop:
 	}
 
 	if req.Status.DownloadURL == "" {
-		return errors.New("file not found")
+		return ErrNotFound
 	}
 
 	httpClient := new(http.Client)
@@ -122,6 +126,10 @@ Loop:
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrapf(err, "request failed: unable to decode response body")
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return ErrNotFound
 		}
 
 		return errors.Errorf("request failed: %v", string(body))

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -234,7 +234,7 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Println()
 
 	if details {
-		printBackupResourceList(d, backup, veleroClient)
+		describeBackupResourceList(d, backup, veleroClient)
 		d.Println()
 	}
 
@@ -258,12 +258,43 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 
 		d.Printf("Persistent Volumes:\n")
 		for _, snap := range snapshots {
-			printSnapshot(d, snap.Spec.PersistentVolumeName, snap.Status.ProviderSnapshotID, snap.Spec.VolumeType, snap.Spec.VolumeAZ, snap.Spec.VolumeIOPS)
+			describeSnapshot(d, snap.Spec.PersistentVolumeName, snap.Status.ProviderSnapshotID, snap.Spec.VolumeType, snap.Spec.VolumeAZ, snap.Spec.VolumeIOPS)
 		}
 		return
 	}
 
 	d.Printf("Persistent Volumes: <none included>\n")
+}
+
+func describeBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
+	buf := new(bytes.Buffer)
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
+		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
+		return
+	}
+
+	var resourceList map[string][]string
+	if err := json.NewDecoder(buf).Decode(&resourceList); err != nil {
+		d.Printf("Resource List:\t<error reading backup resource list: %v>\n", err)
+		return
+	}
+
+	d.Println("Resource List:")
+	for gvk, items := range resourceList {
+		d.Printf("\t%s:\n\t\t- %s\n", gvk, strings.Join(items, "\n\t\t- "))
+	}
+}
+
+func describeSnapshot(d *Describer, pvName, snapshotID, volumeType, volumeAZ string, iops *int64) {
+	d.Printf("\t%s:\n", pvName)
+	d.Printf("\t\tSnapshot ID:\t%s\n", snapshotID)
+	d.Printf("\t\tType:\t%s\n", volumeType)
+	d.Printf("\t\tAvailability Zone:\t%s\n", volumeAZ)
+	iopsString := "<N/A>"
+	if iops != nil {
+		iopsString = fmt.Sprintf("%d", *iops)
+	}
+	d.Printf("\t\tIOPS:\t%s\n", iopsString)
 }
 
 // DescribeDeleteBackupRequests describes delete backup requests in human-readable format.

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -269,7 +269,11 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 func describeBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
 	buf := new(bytes.Buffer)
 	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
-		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
+		if err == downloadrequest.ErrNotFound {
+			d.Println("Resource List:\t<backup resource list not found, this could be because this backup was taken prior to Velero 1.1.0>")
+		} else {
+			d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
+		}
 		return
 	}
 

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -266,37 +266,6 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Printf("Persistent Volumes: <none included>\n")
 }
 
-func printBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
-	buf := new(bytes.Buffer)
-	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
-		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
-		return
-	}
-
-	var resourceList map[string][]string
-	if err := json.NewDecoder(buf).Decode(&resourceList); err != nil {
-		d.Printf("Resource List:\t<error reading backup resource list: %v>\n", err)
-		return
-	}
-
-	d.Println("Resource List:")
-	for gvk, items := range resourceList {
-		d.Printf("\t%s:\n\t\t- %s\n", gvk, strings.Join(items, "\n\t\t- "))
-	}
-}
-
-func printSnapshot(d *Describer, pvName, snapshotID, volumeType, volumeAZ string, iops *int64) {
-	d.Printf("\t%s:\n", pvName)
-	d.Printf("\t\tSnapshot ID:\t%s\n", snapshotID)
-	d.Printf("\t\tType:\t%s\n", volumeType)
-	d.Printf("\t\tAvailability Zone:\t%s\n", volumeAZ)
-	iopsString := "<N/A>"
-	if iops != nil {
-		iopsString = fmt.Sprintf("%d", *iops)
-	}
-	d.Printf("\t\tIOPS:\t%s\n", iopsString)
-}
-
 // DescribeDeleteBackupRequests describes delete backup requests in human-readable format.
 func DescribeDeleteBackupRequests(d *Describer, requests []velerov1api.DeleteBackupRequest) {
 	d.Printf("Deletion Attempts")

--- a/pkg/cmd/util/output/backup_describer.go
+++ b/pkg/cmd/util/output/backup_describer.go
@@ -233,6 +233,11 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	d.Printf("Expiration:\t%s\n", status.Expiration.Time)
 	d.Println()
 
+	if details {
+		printBackupResourceList(d, backup, veleroClient)
+		d.Println()
+	}
+
 	if status.VolumeSnapshotsAttempted > 0 {
 		if !details {
 			d.Printf("Persistent Volumes:\t%d of %d snapshots completed successfully (specify --details for more information)\n", status.VolumeSnapshotsCompleted, status.VolumeSnapshotsAttempted)
@@ -259,6 +264,25 @@ func DescribeBackupStatus(d *Describer, backup *velerov1api.Backup, details bool
 	}
 
 	d.Printf("Persistent Volumes: <none included>\n")
+}
+
+func printBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
+	buf := new(bytes.Buffer)
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
+		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
+		return
+	}
+
+	var resourceList map[string][]string
+	if err := json.NewDecoder(buf).Decode(&resourceList); err != nil {
+		d.Printf("Resource List:\t<error reading backup resource list: %v>\n", err)
+		return
+	}
+
+	d.Println("Resource List:")
+	for gvk, items := range resourceList {
+		d.Printf("\t%s:\n\t\t- %s\n", gvk, strings.Join(items, "\n\t\t- "))
+	}
 }
 
 func printSnapshot(d *Describer, pvName, snapshotID, volumeType, volumeAZ string, iops *int64) {

--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -17,10 +17,13 @@ limitations under the License.
 package output
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 
 	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/cmd/util/downloadrequest"
+	clientset "github.com/heptio/velero/pkg/generated/clientset/versioned"
 )
 
 var (
@@ -127,4 +132,35 @@ func humanReadableTimeFromNow(when time.Time) string {
 	default:
 		return fmt.Sprintf("%s ago", duration.ShortHumanDuration(now.Sub(when)))
 	}
+}
+
+func printBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
+	buf := new(bytes.Buffer)
+	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
+		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
+		return
+	}
+
+	var resourceList map[string][]string
+	if err := json.NewDecoder(buf).Decode(&resourceList); err != nil {
+		d.Printf("Resource List:\t<error reading backup resource list: %v>\n", err)
+		return
+	}
+
+	d.Println("Resource List:")
+	for gvk, items := range resourceList {
+		d.Printf("\t%s:\n\t\t- %s\n", gvk, strings.Join(items, "\n\t\t- "))
+	}
+}
+
+func printSnapshot(d *Describer, pvName, snapshotID, volumeType, volumeAZ string, iops *int64) {
+	d.Printf("\t%s:\n", pvName)
+	d.Printf("\t\tSnapshot ID:\t%s\n", snapshotID)
+	d.Printf("\t\tType:\t%s\n", volumeType)
+	d.Printf("\t\tAvailability Zone:\t%s\n", volumeAZ)
+	iopsString := "<N/A>"
+	if iops != nil {
+		iopsString = fmt.Sprintf("%d", *iops)
+	}
+	d.Printf("\t\tIOPS:\t%s\n", iopsString)
 }

--- a/pkg/cmd/util/output/backup_printer.go
+++ b/pkg/cmd/util/output/backup_printer.go
@@ -17,13 +17,10 @@ limitations under the License.
 package output
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 
 	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
-	"github.com/heptio/velero/pkg/cmd/util/downloadrequest"
-	clientset "github.com/heptio/velero/pkg/generated/clientset/versioned"
 )
 
 var (
@@ -132,35 +127,4 @@ func humanReadableTimeFromNow(when time.Time) string {
 	default:
 		return fmt.Sprintf("%s ago", duration.ShortHumanDuration(now.Sub(when)))
 	}
-}
-
-func printBackupResourceList(d *Describer, backup *velerov1api.Backup, veleroClient clientset.Interface) {
-	buf := new(bytes.Buffer)
-	if err := downloadrequest.Stream(veleroClient.VeleroV1(), backup.Namespace, backup.Name, velerov1api.DownloadTargetKindBackupResourceList, buf, downloadRequestTimeout); err != nil {
-		d.Printf("Resource List:\t<error getting backup resource list: %v>\n", err)
-		return
-	}
-
-	var resourceList map[string][]string
-	if err := json.NewDecoder(buf).Decode(&resourceList); err != nil {
-		d.Printf("Resource List:\t<error reading backup resource list: %v>\n", err)
-		return
-	}
-
-	d.Println("Resource List:")
-	for gvk, items := range resourceList {
-		d.Printf("\t%s:\n\t\t- %s\n", gvk, strings.Join(items, "\n\t\t- "))
-	}
-}
-
-func printSnapshot(d *Describer, pvName, snapshotID, volumeType, volumeAZ string, iops *int64) {
-	d.Printf("\t%s:\n", pvName)
-	d.Printf("\t\tSnapshot ID:\t%s\n", snapshotID)
-	d.Printf("\t\tType:\t%s\n", volumeType)
-	d.Printf("\t\tAvailability Zone:\t%s\n", volumeAZ)
-	iopsString := "<N/A>"
-	if iops != nil {
-		iopsString = fmt.Sprintf("%d", *iops)
-	}
-	d.Printf("\t\tIOPS:\t%s\n", iopsString)
 }

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -438,6 +438,8 @@ func (s *objectBackupStore) GetDownloadURL(target velerov1api.DownloadTarget) (s
 		return s.objectStore.CreateSignedURL(s.bucket, s.layout.getBackupLogKey(target.Name), DownloadURLTTL)
 	case velerov1api.DownloadTargetKindBackupVolumeSnapshots:
 		return s.objectStore.CreateSignedURL(s.bucket, s.layout.getBackupVolumeSnapshotsKey(target.Name), DownloadURLTTL)
+	case velerov1api.DownloadTargetKindBackupResourceList:
+		return s.objectStore.CreateSignedURL(s.bucket, s.layout.getBackupResourceListKey(target.Name), DownloadURLTTL)
 	case velerov1api.DownloadTargetKindRestoreLog:
 		return s.objectStore.CreateSignedURL(s.bucket, s.layout.getRestoreLogKey(target.Name), DownloadURLTTL)
 	case velerov1api.DownloadTargetKindRestoreResults:

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -492,60 +492,72 @@ func TestDeleteBackup(t *testing.T) {
 
 func TestGetDownloadURL(t *testing.T) {
 	tests := []struct {
-		name        string
-		targetKind  velerov1api.DownloadTargetKind
-		targetName  string
-		prefix      string
-		expectedKey string
+		name              string
+		targetName        string
+		expectedKeyByKind map[velerov1api.DownloadTargetKind]string
+		prefix            string
 	}{
 		{
-			name:        "backup contents",
-			targetKind:  velerov1api.DownloadTargetKindBackupContents,
-			targetName:  "my-backup",
-			expectedKey: "backups/my-backup/my-backup.tar.gz",
+			name:       "backup",
+			targetName: "my-backup",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindBackupContents:        "backups/my-backup/my-backup.tar.gz",
+				velerov1api.DownloadTargetKindBackupLog:             "backups/my-backup/my-backup-logs.gz",
+				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/my-backup/my-backup-volumesnapshots.json.gz",
+				velerov1api.DownloadTargetKindBackupResourceList:    "backups/my-backup/my-backup-resource-list.json.gz",
+				velerov1api.DownloadTargetKindRestoreLog:            "restores/my-backup/restore-my-backup-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults:        "restores/my-backup/restore-my-backup-results.gz",
+			},
 		},
 		{
-			name:        "backup log",
-			targetKind:  velerov1api.DownloadTargetKindBackupLog,
-			targetName:  "my-backup",
-			expectedKey: "backups/my-backup/my-backup-logs.gz",
+			name:       "backup with prefix",
+			targetName: "my-backup",
+			prefix:     "velero-backups/",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindBackupContents:        "velero-backups/backups/my-backup/my-backup.tar.gz",
+				velerov1api.DownloadTargetKindBackupLog:             "velero-backups/backups/my-backup/my-backup-logs.gz",
+				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "velero-backups/backups/my-backup/my-backup-volumesnapshots.json.gz",
+				velerov1api.DownloadTargetKindBackupResourceList:    "velero-backups/backups/my-backup/my-backup-resource-list.json.gz",
+				velerov1api.DownloadTargetKindRestoreLog:            "velero-backups/restores/my-backup/restore-my-backup-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults:        "velero-backups/restores/my-backup/restore-my-backup-results.gz",
+			},
 		},
 		{
-			name:        "scheduled backup contents",
-			targetKind:  velerov1api.DownloadTargetKindBackupContents,
-			targetName:  "my-backup-20170913154901",
-			expectedKey: "backups/my-backup-20170913154901/my-backup-20170913154901.tar.gz",
+			name:       "backup with multiple dashes",
+			targetName: "b-cool-20170913154901-20170913154902",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindBackupContents:        "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902.tar.gz",
+				velerov1api.DownloadTargetKindBackupLog:             "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-logs.gz",
+				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-volumesnapshots.json.gz",
+				velerov1api.DownloadTargetKindBackupResourceList:    "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-resource-list.json.gz",
+				velerov1api.DownloadTargetKindRestoreLog:            "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults:        "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-results.gz",
+			},
 		},
 		{
-			name:        "scheduled backup log",
-			targetKind:  velerov1api.DownloadTargetKindBackupLog,
-			targetName:  "my-backup-20170913154901",
-			expectedKey: "backups/my-backup-20170913154901/my-backup-20170913154901-logs.gz",
+			name:       "scheduled backup",
+			targetName: "my-backup-20170913154901",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindBackupContents:        "backups/my-backup-20170913154901/my-backup-20170913154901.tar.gz",
+				velerov1api.DownloadTargetKindBackupLog:             "backups/my-backup-20170913154901/my-backup-20170913154901-logs.gz",
+				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/my-backup-20170913154901/my-backup-20170913154901-volumesnapshots.json.gz",
+				velerov1api.DownloadTargetKindBackupResourceList:    "backups/my-backup-20170913154901/my-backup-20170913154901-resource-list.json.gz",
+				velerov1api.DownloadTargetKindRestoreLog:            "restores/my-backup-20170913154901/restore-my-backup-20170913154901-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults:        "restores/my-backup-20170913154901/restore-my-backup-20170913154901-results.gz",
+			},
 		},
 		{
-			name:        "backup contents with backup store prefix",
-			targetKind:  velerov1api.DownloadTargetKindBackupContents,
-			targetName:  "my-backup",
-			prefix:      "velero-backups/",
-			expectedKey: "velero-backups/backups/my-backup/my-backup.tar.gz",
-		},
-		{
-			name:        "restore log",
-			targetKind:  velerov1api.DownloadTargetKindRestoreLog,
-			targetName:  "b-20170913154901",
-			expectedKey: "restores/b-20170913154901/restore-b-20170913154901-logs.gz",
-		},
-		{
-			name:        "restore results",
-			targetKind:  velerov1api.DownloadTargetKindRestoreResults,
-			targetName:  "b-20170913154901",
-			expectedKey: "restores/b-20170913154901/restore-b-20170913154901-results.gz",
-		},
-		{
-			name:        "restore results - backup has multiple dashes (e.g. restore of scheduled backup)",
-			targetKind:  velerov1api.DownloadTargetKindRestoreResults,
-			targetName:  "b-cool-20170913154901-20170913154902",
-			expectedKey: "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-results.gz",
+			name:       "scheduled backup with prefix",
+			targetName: "my-backup-20170913154901",
+			prefix:     "velero-backups/",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindBackupContents:        "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901.tar.gz",
+				velerov1api.DownloadTargetKindBackupLog:             "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-logs.gz",
+				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-volumesnapshots.json.gz",
+				velerov1api.DownloadTargetKindBackupResourceList:    "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-resource-list.json.gz",
+				velerov1api.DownloadTargetKindRestoreLog:            "velero-backups/restores/my-backup-20170913154901/restore-my-backup-20170913154901-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults:        "velero-backups/restores/my-backup-20170913154901/restore-my-backup-20170913154901-results.gz",
+			},
 		},
 	}
 
@@ -553,11 +565,15 @@ func TestGetDownloadURL(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			harness := newObjectBackupStoreTestHarness("test-bucket", test.prefix)
 
-			require.NoError(t, harness.objectStore.PutObject("test-bucket", test.expectedKey, newStringReadSeeker("foo")))
+			for kind, expectedKey := range test.expectedKeyByKind {
+				t.Run(string(kind), func(t *testing.T) {
+					require.NoError(t, harness.objectStore.PutObject("test-bucket", expectedKey, newStringReadSeeker("foo")))
 
-			url, err := harness.GetDownloadURL(velerov1api.DownloadTarget{Kind: test.targetKind, Name: test.targetName})
-			require.NoError(t, err)
-			assert.Equal(t, "a-url", url)
+					url, err := harness.GetDownloadURL(velerov1api.DownloadTarget{Kind: kind, Name: test.targetName})
+					require.NoError(t, err)
+					assert.Equal(t, "a-url", url)
+				})
+			}
 		})
 	}
 }

--- a/pkg/persistence/object_store_test.go
+++ b/pkg/persistence/object_store_test.go
@@ -505,8 +505,6 @@ func TestGetDownloadURL(t *testing.T) {
 				velerov1api.DownloadTargetKindBackupLog:             "backups/my-backup/my-backup-logs.gz",
 				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/my-backup/my-backup-volumesnapshots.json.gz",
 				velerov1api.DownloadTargetKindBackupResourceList:    "backups/my-backup/my-backup-resource-list.json.gz",
-				velerov1api.DownloadTargetKindRestoreLog:            "restores/my-backup/restore-my-backup-logs.gz",
-				velerov1api.DownloadTargetKindRestoreResults:        "restores/my-backup/restore-my-backup-results.gz",
 			},
 		},
 		{
@@ -518,8 +516,6 @@ func TestGetDownloadURL(t *testing.T) {
 				velerov1api.DownloadTargetKindBackupLog:             "velero-backups/backups/my-backup/my-backup-logs.gz",
 				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "velero-backups/backups/my-backup/my-backup-volumesnapshots.json.gz",
 				velerov1api.DownloadTargetKindBackupResourceList:    "velero-backups/backups/my-backup/my-backup-resource-list.json.gz",
-				velerov1api.DownloadTargetKindRestoreLog:            "velero-backups/restores/my-backup/restore-my-backup-logs.gz",
-				velerov1api.DownloadTargetKindRestoreResults:        "velero-backups/restores/my-backup/restore-my-backup-results.gz",
 			},
 		},
 		{
@@ -530,8 +526,6 @@ func TestGetDownloadURL(t *testing.T) {
 				velerov1api.DownloadTargetKindBackupLog:             "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-logs.gz",
 				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-volumesnapshots.json.gz",
 				velerov1api.DownloadTargetKindBackupResourceList:    "backups/b-cool-20170913154901-20170913154902/b-cool-20170913154901-20170913154902-resource-list.json.gz",
-				velerov1api.DownloadTargetKindRestoreLog:            "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-logs.gz",
-				velerov1api.DownloadTargetKindRestoreResults:        "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-results.gz",
 			},
 		},
 		{
@@ -542,8 +536,6 @@ func TestGetDownloadURL(t *testing.T) {
 				velerov1api.DownloadTargetKindBackupLog:             "backups/my-backup-20170913154901/my-backup-20170913154901-logs.gz",
 				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "backups/my-backup-20170913154901/my-backup-20170913154901-volumesnapshots.json.gz",
 				velerov1api.DownloadTargetKindBackupResourceList:    "backups/my-backup-20170913154901/my-backup-20170913154901-resource-list.json.gz",
-				velerov1api.DownloadTargetKindRestoreLog:            "restores/my-backup-20170913154901/restore-my-backup-20170913154901-logs.gz",
-				velerov1api.DownloadTargetKindRestoreResults:        "restores/my-backup-20170913154901/restore-my-backup-20170913154901-results.gz",
 			},
 		},
 		{
@@ -555,8 +547,31 @@ func TestGetDownloadURL(t *testing.T) {
 				velerov1api.DownloadTargetKindBackupLog:             "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-logs.gz",
 				velerov1api.DownloadTargetKindBackupVolumeSnapshots: "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-volumesnapshots.json.gz",
 				velerov1api.DownloadTargetKindBackupResourceList:    "velero-backups/backups/my-backup-20170913154901/my-backup-20170913154901-resource-list.json.gz",
-				velerov1api.DownloadTargetKindRestoreLog:            "velero-backups/restores/my-backup-20170913154901/restore-my-backup-20170913154901-logs.gz",
-				velerov1api.DownloadTargetKindRestoreResults:        "velero-backups/restores/my-backup-20170913154901/restore-my-backup-20170913154901-results.gz",
+			},
+		},
+		{
+			name:       "restore",
+			targetName: "my-backup",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindRestoreLog:     "restores/my-backup/restore-my-backup-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults: "restores/my-backup/restore-my-backup-results.gz",
+			},
+		},
+		{
+			name:       "restore with prefix",
+			targetName: "my-backup",
+			prefix:     "velero-backups/",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindRestoreLog:     "velero-backups/restores/my-backup/restore-my-backup-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults: "velero-backups/restores/my-backup/restore-my-backup-results.gz",
+			},
+		},
+		{
+			name:       "restore with multiple dashes",
+			targetName: "b-cool-20170913154901-20170913154902",
+			expectedKeyByKind: map[velerov1api.DownloadTargetKind]string{
+				velerov1api.DownloadTargetKindRestoreLog:     "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-logs.gz",
+				velerov1api.DownloadTargetKindRestoreResults: "restores/b-cool-20170913154901-20170913154902/restore-b-cool-20170913154901-20170913154902-results.gz",
 			},
 		},
 	}


### PR DESCRIPTION
Download and print backup resource list metadata when running `velero backup describe --details <name>`.

e.g.
```
$ velero backup describe --details nginx-backup-2
Name:         nginx-backup-2
Namespace:    velero
Labels:       velero.io/storage-location=default
Annotations:  <none>

Phase:  PartiallyFailed (run `velero backup logs nginx-backup-2` for more information)

Errors:    2
Warnings:  0

Namespaces:
  Included:  *
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        <none>
  Cluster-scoped:  auto

Label selector:  app=nginx

Storage Location:  default

Snapshot PVs:  auto

TTL:  720h0m0s

Hooks:  <none>

Backup Format Version:  1

Started:    2019-07-31 13:55:29 -0700 PDT
Completed:  2019-07-31 13:55:46 -0700 PDT

Expiration:  2019-08-30 13:55:29 -0700 PDT

Resource List:
  apps/v1/ReplicaSet:
    - nginx-example/nginx-deployment-5b658f5d7f
    - nginx-example/nginx-deployment-75675f5897
  v1/Endpoints:
    - nginx-example/my-nginx
  v1/Namespace:
    - nginx-example
  v1/PersistentVolume:
    - pvc-dd06dd30-b259-11e9-a63b-025000000001
  v1/PersistentVolumeClaim:
    - nginx-example/nginx-logs
  v1/Pod:
    - nginx-example/nginx-deployment-5b658f5d7f-28qpb
  v1/Service:
    - nginx-example/my-nginx

Persistent Volumes: <none included>
```


depends on #1709 

fixes #396 

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>