### PR TITLE
Added Kubernetes Cronjob yaml for automated backup

### DIFF
--- a/changelogs/unreleased/0000-saibaldey
+++ b/changelogs/unreleased/0000-saibaldey
@@ -1,0 +1,1 @@
+Added Kubernetes Cronjob yaml for automated backup

--- a/docs/aws-config.md
+++ b/docs/aws-config.md
@@ -197,6 +197,10 @@ Specify the following values in the example files:
           aws ec2 describe-tags --filters "Name=resource-id,Values=<ID>" "Name=key,Values=KubernetesCluster"
         ```
 
+* (Optional, use only to create Kubernetes Cronjob for automated backup) In `config/aws/15-backup-cronjob.yaml`:
+
+  * Replace `<NAME OF BACKUP>`,`<NAMESPACES(s) TO BE INCLUDED>`,`<RESOURCE(s) TO BE INCLUDED/CONSIDERD FOR BACKUP>` and `<LABEL(s) TO BE CONSIDERD FOR BACKUP>` with proper values.(Incase all namespaces to be considered, replace `<NAMESPACES(s) TO BE INCLUDED>` with *. For more details check the velero CLI documentations.
+
 ## Start the server
 
 In the root of your Velero directory, run:

--- a/examples/aws/15-backup-cronjob.yaml
+++ b/examples/aws/15-backup-cronjob.yaml
@@ -1,0 +1,45 @@
+# Copyright 2018 the Heptio Ark contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: velero-backup-cronjob
+  namespace: velero
+spec:
+  schedule: "0 0 * * *"  #default backup schedule daily once at midnight 
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 240
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: velero
+          containers:
+            - name: velero
+              image: gcr.io/heptio-images/velero:latest
+              command:
+                - /velero
+              args:
+                - create
+                - backup
+                - <NAME OF BACKUP>
+                - --include-namespaces
+                - <NAMESPACES(s) TO BE INCLUDED>
+                - --include-resources
+                - <RESOURCE(s) TO BE INCLUDED/CONSIDERD FOR BACKUP>
+                - --selector
+                - <LABEL(s) TO BE CONSIDERD FOR BACKUP> #Useful option to group multiple resources together applying the same label


### PR DESCRIPTION
Added Kubernetes Cronjob Object creation (yaml file in examples/aws/ file) for automated backup creation. User will have option to take backup of the required objects using "kubernetes cronjob". The admin will no more required to take backups using "velero" binary/client through a terminal.

Signed-off-by: Saibal Dey <saibal83.dey@gmail.com>