### PR TITLE
use Backup CR labels as tags for snapshots

### DIFF
--- a/changelogs/unreleased/1729-prydonius
+++ b/changelogs/unreleased/1729-prydonius
@@ -1,0 +1,1 @@
+adds the ability to define custom tags to be added to snapshots by specifying custom labels on the Backup CR with the velero backup create --labels flag

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -436,6 +436,9 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 	log = log.WithField("volumeID", volumeID)
 
 	tags := ib.backupRequest.GetLabels()
+	if tags == nil {
+		tags = map[string]string{}
+	}
 	tags["velero.io/backup"] = ib.backupRequest.Name
 	tags["velero.io/pv"] = pv.Name
 

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -435,10 +435,9 @@ func (ib *defaultItemBackupper) takePVSnapshot(obj runtime.Unstructured, log log
 
 	log = log.WithField("volumeID", volumeID)
 
-	tags := map[string]string{
-		"velero.io/backup": ib.backupRequest.Name,
-		"velero.io/pv":     pv.Name,
-	}
+	tags := ib.backupRequest.GetLabels()
+	tags["velero.io/backup"] = ib.backupRequest.Name
+	tags["velero.io/pv"] = pv.Name
 
 	log.Info("Getting volume information")
 	volumeType, iops, err := volumeSnapshotter.GetVolumeInfo(volumeID, pvFailureDomainZone)


### PR DESCRIPTION
This allows users to define custom tags to be added to snapshots, by
specifying custom labels on the Backup CR with the `velero backup create
--labels` flag.

closes #1132

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>