### PR TITLE
create backups from schedules using velero create backup

### DIFF
--- a/changelogs/unreleased/1734-prydonius
+++ b/changelogs/unreleased/1734-prydonius
@@ -1,0 +1,1 @@
+adds --from-schedule flag to the `velero create backup` command to create a Backup from an existing Schedule

--- a/pkg/builder/backup_builder.go
+++ b/pkg/builder/backup_builder.go
@@ -73,6 +73,19 @@ func (b *BackupBuilder) ObjectMeta(opts ...ObjectMetaOpt) *BackupBuilder {
 	return b
 }
 
+// FromSchedule sets the Backup's spec and labels from the Schedule template
+func (b *BackupBuilder) FromSchedule(schedule *velerov1api.Schedule) *BackupBuilder {
+	labels := schedule.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[velerov1api.ScheduleNameLabel] = schedule.Name
+
+	b.object.Spec = schedule.Spec.Template
+	b.ObjectMeta(WithLabelsMap(labels))
+	return b
+}
+
 // IncludedNamespaces sets the Backup's included namespaces.
 func (b *BackupBuilder) IncludedNamespaces(namespaces ...string) *BackupBuilder {
 	b.object.Spec.IncludedNamespaces = namespaces

--- a/pkg/builder/backup_builder.go
+++ b/pkg/builder/backup_builder.go
@@ -164,12 +164,6 @@ func (b *BackupBuilder) StartTimestamp(val time.Time) *BackupBuilder {
 	return b
 }
 
-// NoTypeMeta removes the type meta from the Backup.
-func (b *BackupBuilder) NoTypeMeta() *BackupBuilder {
-	b.object.TypeMeta = metav1.TypeMeta{}
-	return b
-}
-
 // Hooks sets the Backup's hooks.
 func (b *BackupBuilder) Hooks(hooks velerov1api.BackupHooks) *BackupBuilder {
 	b.object.Spec.Hooks = hooks

--- a/pkg/builder/object_meta.go
+++ b/pkg/builder/object_meta.go
@@ -42,6 +42,23 @@ func WithLabels(vals ...string) func(obj metav1.Object) {
 	}
 }
 
+// WithLabelsMap is a functional option that applies the specified labels map to
+// an object.
+func WithLabelsMap(labels map[string]string) func(obj metav1.Object) {
+	return func(obj metav1.Object) {
+		objLabels := obj.GetLabels()
+		if objLabels == nil {
+			objLabels = make(map[string]string)
+		}
+
+		for k, v := range labels {
+			objLabels[k] = v
+		}
+
+		obj.SetLabels(objLabels)
+	}
+}
+
 // WithAnnotations is a functional option that applies the specified
 // annotation keys/values to an object.
 func WithAnnotations(vals ...string) func(obj metav1.Object) {

--- a/pkg/builder/object_meta.go
+++ b/pkg/builder/object_meta.go
@@ -51,6 +51,7 @@ func WithLabelsMap(labels map[string]string) func(obj metav1.Object) {
 			objLabels = make(map[string]string)
 		}
 
+		// If the label already exists in the object, it will be overwritten
 		for k, v := range labels {
 			objLabels[k] = v
 		}
@@ -83,6 +84,7 @@ func setMapEntries(m map[string]string, vals ...string) map[string]string {
 		key := vals[i]
 		val := vals[i+1]
 
+		// If the label already exists in the object, it will be overwritten
 		m[key] = val
 	}
 

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -17,7 +17,6 @@ limitations under the License.
 package backup
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -140,17 +139,6 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 		return err
 	}
 
-	if o.FromSchedule != "" {
-		if (len(o.IncludeNamespaces) > 1 || o.IncludeNamespaces[0] != "*") ||
-			len(o.ExcludeNamespaces) > 0 || len(o.IncludeResources) > 0 ||
-			len(o.ExcludeResources) > 0 || o.Selector.LabelSelector != nil ||
-			o.SnapshotVolumes.Value != nil || o.TTL != DefaultBackupTTL ||
-			o.IncludeClusterResources.Value != nil ||
-			o.StorageLocation != "" || len(o.SnapshotLocations) > 0 {
-			return errors.New("backup filters cannot be set when creating a Backup from a Schedule")
-		}
-	}
-
 	if o.StorageLocation != "" {
 		if _, err := o.client.VeleroV1().BackupStorageLocations(f.Namespace()).Get(o.StorageLocation, metav1.GetOptions{}); err != nil {
 			return err
@@ -208,6 +196,10 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	if printed, err := output.PrintWithFormat(c, backup); printed || err != nil {
 		return err
+	}
+
+	if o.FromSchedule != "" {
+		fmt.Println("Creating backup from schedule, all other filters are ignored.")
 	}
 
 	var backupInformer cache.SharedIndexInformer

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	api "github.com/heptio/velero/pkg/apis/velero/v1"
 	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/heptio/velero/pkg/builder"
 	"github.com/heptio/velero/pkg/client"
@@ -180,19 +179,19 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	var backupInformer cache.SharedIndexInformer
-	var updates chan *api.Backup
+	var updates chan *velerov1api.Backup
 	if o.Wait {
 		stop := make(chan struct{})
 		defer close(stop)
 
-		updates = make(chan *api.Backup)
+		updates = make(chan *velerov1api.Backup)
 
 		backupInformer = v1.NewBackupInformer(o.client, f.Namespace(), 0, nil)
 
 		backupInformer.AddEventHandler(
 			cache.FilteringResourceEventHandler{
 				FilterFunc: func(obj interface{}) bool {
-					backup, ok := obj.(*api.Backup)
+					backup, ok := obj.(*velerov1api.Backup)
 					if !ok {
 						return false
 					}
@@ -200,14 +199,14 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 				},
 				Handler: cache.ResourceEventHandlerFuncs{
 					UpdateFunc: func(_, obj interface{}) {
-						backup, ok := obj.(*api.Backup)
+						backup, ok := obj.(*velerov1api.Backup)
 						if !ok {
 							return
 						}
 						updates <- backup
 					},
 					DeleteFunc: func(obj interface{}) {
-						backup, ok := obj.(*api.Backup)
+						backup, ok := obj.(*velerov1api.Backup)
 						if !ok {
 							return
 						}
@@ -240,7 +239,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 					return nil
 				}
 
-				if backup.Status.Phase != api.BackupPhaseNew && backup.Status.Phase != api.BackupPhaseInProgress {
+				if backup.Status.Phase != velerov1api.BackupPhaseNew && backup.Status.Phase != velerov1api.BackupPhaseInProgress {
 					fmt.Printf("\nBackup completed with status: %s. You may check for more information using the commands `velero backup describe %s` and `velero backup logs %s`.\n", backup.Status.Phase, backup.Name, backup.Name)
 					return nil
 				}

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -68,6 +68,7 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 
 	o.BindFlags(c.Flags())
 	o.BindWait(c.Flags())
+	o.BindFromSchedule(c.Flags())
 	output.BindFlags(c.Flags())
 	output.ClearOutputFlagDefault(c)
 
@@ -113,7 +114,6 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.StorageLocation, "storage-location", "", "location in which to store the backup")
 	flags.StringSliceVar(&o.SnapshotLocations, "volume-snapshot-locations", o.SnapshotLocations, "list of locations (at most one per provider) where volume snapshots should be stored")
 	flags.VarP(&o.Selector, "selector", "l", "only back up resources matching this label selector")
-	flags.StringVar(&o.FromSchedule, "from-schedule", "", "create a backup from a Schedule. Cannot be used with any other filters.")
 	f := flags.VarPF(&o.SnapshotVolumes, "snapshot-volumes", "", "take snapshots of PersistentVolumes as part of the backup")
 	// this allows the user to just specify "--snapshot-volumes" as shorthand for "--snapshot-volumes=true"
 	// like a normal bool flag
@@ -127,6 +127,12 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 // commands that reuse CreateOptions's BindFlags method.
 func (o *CreateOptions) BindWait(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.Wait, "wait", "w", o.Wait, "wait for the operation to complete")
+}
+
+// BindFromSchedule binds the from-schedule flag separately so it is not called
+// by other create commands that reuse CreateOptions's BindFlags method.
+func (o *CreateOptions) BindFromSchedule(flags *pflag.FlagSet) {
+	flags.StringVar(&o.FromSchedule, "from-schedule", "", "create a backup from a Schedule. Cannot be used with any other filters.")
 }
 
 func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -132,7 +132,7 @@ func (o *CreateOptions) BindWait(flags *pflag.FlagSet) {
 // BindFromSchedule binds the from-schedule flag separately so it is not called
 // by other create commands that reuse CreateOptions's BindFlags method.
 func (o *CreateOptions) BindFromSchedule(flags *pflag.FlagSet) {
-	flags.StringVar(&o.FromSchedule, "from-schedule", "", "create a backup from a Schedule. Cannot be used with any other filters.")
+	flags.StringVar(&o.FromSchedule, "from-schedule", "", "create a backup from the template of an existing schedule. Cannot be used with any other filters.")
 }
 
 func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Factory) error {

--- a/pkg/cmd/cli/backup/create.go
+++ b/pkg/cmd/cli/backup/create.go
@@ -21,14 +21,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/heptio/velero/pkg/builder"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/builder"
 	"github.com/heptio/velero/pkg/client"
 	"github.com/heptio/velero/pkg/cmd"
 	"github.com/heptio/velero/pkg/cmd/util/flag"

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"testing"
+
+	"github.com/heptio/velero/pkg/builder"
+
+	"github.com/heptio/velero/pkg/generated/clientset/versioned/fake"
+
+	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testNamespace = "velero"
+
+func TestCreateOptions_BuildBackup(t *testing.T) {
+	o := NewCreateOptions()
+	o.Labels.Set("velero.io/test=true")
+
+	backup, err := o.BuildBackup(testNamespace)
+	assert.NoError(t, err)
+
+	assert.Equal(t, velerov1api.BackupSpec{
+		TTL:                     metav1.Duration{Duration: o.TTL},
+		IncludedNamespaces:      []string(o.IncludeNamespaces),
+		SnapshotVolumes:         o.SnapshotVolumes.Value,
+		IncludeClusterResources: o.IncludeClusterResources.Value,
+	}, backup.Spec)
+
+	assert.Equal(t, map[string]string{
+		"velero.io/test": "true",
+	}, backup.GetLabels())
+}
+
+func TestCreateOptions_BuildBackupFromSchedule(t *testing.T) {
+	o := NewCreateOptions()
+	o.FromSchedule = "test"
+	o.client = fake.NewSimpleClientset()
+
+	t.Run("inexistant schedule", func(t *testing.T) {
+		_, err := o.BuildBackup(testNamespace)
+		assert.Error(t, err)
+	})
+
+	expectedBackupSpec := builder.ForBackup("test", testNamespace).IncludedNamespaces("test").Result().Spec
+	schedule := builder.ForSchedule(testNamespace, "test").Template(expectedBackupSpec).ObjectMeta(builder.WithLabels("velero.io/test", "true")).Result()
+	o.client.VeleroV1().Schedules(testNamespace).Create(schedule)
+
+	t.Run("existing schedule", func(t *testing.T) {
+		backup, err := o.BuildBackup(testNamespace)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedBackupSpec, backup.Spec)
+		assert.Equal(t, map[string]string{
+			"velero.io/test":              "true",
+			velerov1api.ScheduleNameLabel: "test",
+		}, backup.GetLabels())
+	})
+
+	t.Run("command line labels take precedence over schedule labels", func(t *testing.T) {
+		o.Labels.Set("velero.io/test=yes,custom-label=true")
+		backup, err := o.BuildBackup(testNamespace)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedBackupSpec, backup.Spec)
+		assert.Equal(t, map[string]string{
+			"velero.io/test":              "yes",
+			velerov1api.ScheduleNameLabel: "test",
+			"custom-label":                "true",
+		}, backup.GetLabels())
+	})
+}

--- a/pkg/cmd/cli/backup/create_test.go
+++ b/pkg/cmd/cli/backup/create_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 the Velero contributors.
+Copyright 2019 the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ package backup
 import (
 	"testing"
 
-	"github.com/heptio/velero/pkg/builder"
-
-	"github.com/heptio/velero/pkg/generated/clientset/versioned/fake"
-
-	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/builder"
+	"github.com/heptio/velero/pkg/generated/clientset/versioned/fake"
 )
 
 const testNamespace = "velero"

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -93,9 +93,6 @@ func NewCreateOptions() *CreateOptions {
 
 func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	o.BackupOptions.BindFlags(flags)
-	// hide the Backup options --from-schedule flag
-	// TODO: see if there is a way to remove the flag
-	flags.MarkHidden("from-schedule")
 	flags.StringVar(&o.Schedule, "schedule", o.Schedule, "a cron expression specifying a recurring schedule for this backup to run")
 }
 

--- a/pkg/cmd/cli/schedule/create.go
+++ b/pkg/cmd/cli/schedule/create.go
@@ -93,6 +93,9 @@ func NewCreateOptions() *CreateOptions {
 
 func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 	o.BackupOptions.BindFlags(flags)
+	// hide the Backup options --from-schedule flag
+	// TODO: see if there is a way to remove the flag
+	flags.MarkHidden("from-schedule")
 	flags.StringVar(&o.Schedule, "schedule", o.Schedule, "a cron expression specifying a recurring schedule for this backup to run")
 }
 

--- a/pkg/controller/schedule_controller_test.go
+++ b/pkg/controller/schedule_controller_test.go
@@ -97,7 +97,7 @@ func TestProcessSchedule(t *testing.T) {
 			fakeClockTime:        "2017-01-01 12:00:00",
 			expectedErr:          false,
 			expectedPhase:        string(velerov1api.SchedulePhaseEnabled),
-			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).NoTypeMeta().Result(),
+			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).Result(),
 			expectedLastBackup:   "2017-01-01 12:00:00",
 		},
 		{
@@ -105,7 +105,7 @@ func TestProcessSchedule(t *testing.T) {
 			schedule:             newScheduleBuilder(velerov1api.SchedulePhaseEnabled).CronSchedule("@every 5m").Result(),
 			fakeClockTime:        "2017-01-01 12:00:00",
 			expectedErr:          false,
-			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).NoTypeMeta().Result(),
+			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).Result(),
 			expectedLastBackup:   "2017-01-01 12:00:00",
 		},
 		{
@@ -113,7 +113,7 @@ func TestProcessSchedule(t *testing.T) {
 			schedule:             newScheduleBuilder(velerov1api.SchedulePhaseEnabled).CronSchedule("@every 5m").LastBackupTime("2000-01-01 00:00:00").Result(),
 			fakeClockTime:        "2017-01-01 12:00:00",
 			expectedErr:          false,
-			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).NoTypeMeta().Result(),
+			expectedBackupCreate: builder.ForBackup("ns", "name-20170101120000").ObjectMeta(builder.WithLabels(velerov1api.ScheduleNameLabel, "name")).Result(),
 			expectedLastBackup:   "2017-01-01 12:00:00",
 		},
 	}


### PR DESCRIPTION
Adds a flag `--from-schedule` to the velero create backup command to create a Backup from an existing Schedule.

Signed-off-by: Adnan Abdulhussein <aadnan@vmware.com>

closes #656