### PR TITLE
bug fix: upload pod volume backups from *all* pods to obj storage

### DIFF
--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -219,7 +219,8 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 		// this function will return partial results, so process podVolumeBackups
 		// even if there are errors.
 		podVolumeBackups, errs := ib.backupPodVolumes(log, pod, resticVolumesToBackup)
-		ib.backupRequest.PodVolumeBackups = podVolumeBackups
+
+		ib.backupRequest.PodVolumeBackups = append(ib.backupRequest.PodVolumeBackups, podVolumeBackups...)
 		backupErrs = append(backupErrs, errs...)
 	}
 


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Current code is effectively only saving PVB's from the *last* pod since it's not appending.