### PR TITLE
Allow BSLs to specify restic repo prefixes, error if the prefix can't be determined

### DIFF
--- a/pkg/restic/config.go
+++ b/pkg/restic/config.go
@@ -57,6 +57,10 @@ func getRepoPrefix(location *velerov1api.BackupStorageLocation) (string, error) 
 		provider = "velero.io/" + provider
 	}
 
+	if repoPrefix := location.Spec.Config["resticRepoPrefix"]; repoPrefix != "" {
+		return repoPrefix, nil
+	}
+
 	switch BackendType(provider) {
 	case AWSBackend:
 		var url string

--- a/pkg/restic/config_test.go
+++ b/pkg/restic/config_test.go
@@ -42,7 +42,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "s3:s3.amazonaws.com/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err := GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3:s3.amazonaws.com/bucket/prefix/restic/repo-1", id)
 
 	// stub implementation of getAWSBucketRegion
 	getAWSBucketRegion = func(string) (string, error) {
@@ -59,7 +61,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "s3:s3-us-west-2.amazonaws.com/bucket/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3:s3-us-west-2.amazonaws.com/bucket/restic/repo-1", id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{
@@ -72,7 +76,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "s3:s3-us-west-2.amazonaws.com/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3:s3-us-west-2.amazonaws.com/bucket/prefix/restic/repo-1", id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{
@@ -88,7 +94,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "s3:alternate-url/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3:alternate-url/bucket/prefix/restic/repo-1", id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{
@@ -104,7 +112,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "s3:alternate-url-with-trailing-slash/bucket/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "s3:alternate-url-with-trailing-slash/bucket/prefix/restic/repo-1", id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{
@@ -117,7 +127,9 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "azure:bucket:/prefix/restic/repo-1", GetRepoIdentifier(backupLocation, "repo-1"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "azure:bucket:/prefix/restic/repo-1", id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{
 		Spec: velerov1api.BackupStorageLocationSpec{
@@ -130,5 +142,40 @@ func TestGetRepoIdentifier(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, "gs:bucket-2:/prefix-2/restic/repo-2", GetRepoIdentifier(backupLocation, "repo-2"))
+	id, err = GetRepoIdentifier(backupLocation, "repo-2")
+	assert.NoError(t, err)
+	assert.Equal(t, "gs:bucket-2:/prefix-2/restic/repo-2", id)
+
+	backupLocation = &velerov1api.BackupStorageLocation{
+		Spec: velerov1api.BackupStorageLocationSpec{
+			Provider: "unsupported-provider",
+			StorageType: velerov1api.StorageType{
+				ObjectStorage: &velerov1api.ObjectStorageLocation{
+					Bucket: "bucket-2",
+					Prefix: "prefix-2",
+				},
+			},
+		},
+	}
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.EqualError(t, err, "cannot determine restic repository prefix for backup storage location")
+	assert.Empty(t, id)
+
+	backupLocation = &velerov1api.BackupStorageLocation{
+		Spec: velerov1api.BackupStorageLocationSpec{
+			Provider: "custom-repo-identifier",
+			Config: map[string]string{
+				"resticRepoPrefix": "custom:prefix:/restic",
+			},
+			StorageType: velerov1api.StorageType{
+				ObjectStorage: &velerov1api.ObjectStorageLocation{
+					Bucket: "bucket",
+					Prefix: "prefix",
+				},
+			},
+		},
+	}
+	id, err = GetRepoIdentifier(backupLocation, "repo-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "custom:prefix:/restic/repo-1", id)
 }

--- a/pkg/restic/config_test.go
+++ b/pkg/restic/config_test.go
@@ -158,7 +158,7 @@ func TestGetRepoIdentifier(t *testing.T) {
 		},
 	}
 	id, err = GetRepoIdentifier(backupLocation, "repo-1")
-	assert.EqualError(t, err, "cannot determine restic repository prefix for backup storage location")
+	assert.EqualError(t, err, "restic repository prefix (resticRepoPrefix) not specified in backup storage location's config")
 	assert.Empty(t, id)
 
 	backupLocation = &velerov1api.BackupStorageLocation{


### PR DESCRIPTION
Fixes #939 

Hold for merge until after v1.1

This PR does two things:

1. If Velero can't determine the restic repo identifier for a given restic repository/BackupStorageLocation, it leaves the field blank and sets the repo to "NotReady" rather than putting an invalid repo identifier in the field and attempting to initialize it
2. Addresses #939 by allowing an optional `resticRepoPrefix` config key/val to be specified in a BSL, which if specified takes precedence over the auto-determined one.

Coupled with previously merged PRs around failing faster if a restic repo can't be initialized, this should make the UX much clearer when something goes wrong around creating a repo, particularly for third-party object store plugins.