### PR TITLE
Add the prefix to BSL config map so that object stores can use it whe…

### DIFF
--- a/changelogs/unreleased/1767-betta1
+++ b/changelogs/unreleased/1767-betta1
@@ -1,0 +1,1 @@
+Add the prefix to BSL config map so that object stores can use it when initializing

--- a/pkg/cloudprovider/config.go
+++ b/pkg/cloudprovider/config.go
@@ -23,11 +23,11 @@ import (
 
 // ValidateObjectStoreConfigKeys ensures that an object store's config
 // is valid by making sure each `config` key is in the `validKeys` list.
-// The special key "bucket" is always considered valid.
+// The special keys "bucket" and "prefix" are always considered valid.
 func ValidateObjectStoreConfigKeys(config map[string]string, validKeys ...string) error {
-	// `bucket` is automatically added to all object store config by
-	// velero, so add it as a valid key.
-	return validateConfigKeys(config, append(validKeys, "bucket")...)
+	// `bucket` and `prefix` are automatically added to all object
+	// store config by velero, so add them as valid keys.
+	return validateConfigKeys(config, append(validKeys, "bucket", "prefix")...)
 }
 
 // ValidateVolumeSnapshotterConfigKeys ensures that a volume snapshotter's

--- a/pkg/persistence/object_store.go
+++ b/pkg/persistence/object_store.go
@@ -107,14 +107,15 @@ func NewObjectBackupStore(location *velerov1api.BackupStorageLocation, objectSto
 		return nil, errors.Errorf("backup storage location's bucket name %q must not contain a '/' (if using a prefix, put it in the 'Prefix' field instead)", location.Spec.ObjectStorage.Bucket)
 	}
 
-	// add the bucket name to the config map so that object stores can use
-	// it when initializing. The AWS object store uses this to determine the
-	// bucket's region when setting up its client.
+	// add the bucket name and prefix to the config map so that object stores
+	// can use them when initializing. The AWS object store uses the bucket
+	// name to determine the bucket's region when setting up its client.
 	if location.Spec.ObjectStorage != nil {
 		if location.Spec.Config == nil {
 			location.Spec.Config = make(map[string]string)
 		}
 		location.Spec.Config["bucket"] = bucket
+		location.Spec.Config["prefix"] = prefix
 	}
 
 	objectStore, err := objectStoreGetter.GetObjectStore(location.Spec.Provider)


### PR DESCRIPTION
…n initializing

Signed-off-by: Antony Bett <antony.bett@gmail.com>