### PR TITLE
fix error formatting

### DIFF
--- a/changelogs/unreleased/1781-s12chung
+++ b/changelogs/unreleased/1781-s12chung
@@ -1,0 +1,1 @@
+fix error formatting due interpreting % as printf formatted strings

--- a/pkg/cmd/errors.go
+++ b/pkg/cmd/errors.go
@@ -27,7 +27,7 @@ import (
 func CheckError(err error) {
 	if err != nil {
 		if err != context.Canceled {
-			fmt.Fprintf(os.Stderr, fmt.Sprintf("An error occurred: %v\n", err))
+			fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
would interpret % as printf formatted strings

example:

```bash
# previous (look for %!F(MISSING))
steve-meso-pro:velero main$ ./_output/velero_darwin_amd64/velero backup download velero-kubeaddons-default-20190802002731
An error occurred: "Get https://ac04fbf1bf3114b2c91ef10808c5ba32-2028105485.us-west-2.elb.amazonaws.com:9000/velero/backups/velero-kubeaddons-default-20190802002731/velero-kubeaddons-default-20190802002731.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=minio%!F(MISSING)20190821%!F(MISSING)fallback%!F(MISSING)s3%!F(MISSING)aws4_request&X-Amz-Date=20190821T030947Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=528dc9c40580a99d8e6ef9d62fb7bd97c7d6f6a332cdd898a7907fd40ffbcf9b: x509: certificate signed by unknown authority"

# fixed
steve-meso-pro:velero main$ ./_output/velero_darwin_amd64/velero backup download velero-kubeaddons-default-20190802002731
An error occurred: "Get https://ac04fbf1bf3114b2c91ef10808c5ba32-2028105485.us-west-2.elb.amazonaws.com:9000/velero/backups/velero-kubeaddons-default-20190802002731/velero-kubeaddons-default-20190802002731.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=minio%2F20190821%2Ffallback%2Fs3%2Faws4_request&X-Amz-Date=20190821T031121Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=69309f953ad25d0fff0d1fb02e82c233c927e8dbdf0e85d6376bccdfddfcc5f9: x509: certificate signed by unknown authority"
```