### PR TITLE
create pkg/archive with functionality extracted from pkg/restore

### DIFF
--- a/pkg/archive/parser.go
+++ b/pkg/archive/parser.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	velerov1api "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/heptio/velero/pkg/util/filesystem"
+)
+
+// Parser traverses an extracted archive on disk to validate
+// it and provide a helpful representation of it to consumers.
+type Parser struct {
+	fs filesystem.Interface
+}
+
+// ResourceItems contains the collection of items of a given resource type
+// within a backup, grouped by namespace (or empty string for cluster-scoped
+// resources).
+type ResourceItems struct {
+	// GroupResource is API group and resource name,
+	// formatted as "resource.group". For the "core"
+	// API group, the ".group" suffix is omitted.
+	GroupResource string
+
+	// ItemsByNamespace is a map from namespace (or empty string
+	// for cluster-scoped resources) to a list of individual item
+	// names contained in the archive. Item names **do not** include
+	// the file extension.
+	ItemsByNamespace map[string][]string
+}
+
+// NewParser constructs a Parser.
+func NewParser(fs filesystem.Interface) *Parser {
+	return &Parser{
+		fs: fs,
+	}
+}
+
+// Parse reads an extracted backup on the file system and returns
+// a structured catalog of the resources and items contained within it.
+func (p *Parser) Parse(dir string) (map[string]*ResourceItems, error) {
+	// ensure top-level "resources" directory exists, and read subdirectories
+	// of it, where each one is expected to correspond to a resource.
+	resourcesDir := filepath.Join(dir, velerov1api.ResourcesDir)
+	exists, err := p.fs.DirExists(resourcesDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking for existence of directory %q", strings.TrimPrefix(resourcesDir, dir+"/"))
+	}
+	if !exists {
+		return nil, errors.Errorf("directory %q does not exist", strings.TrimPrefix(resourcesDir, dir+"/"))
+	}
+
+	resourceDirs, err := p.fs.ReadDir(resourcesDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading contents of directory %q", strings.TrimPrefix(resourcesDir, dir+"/"))
+	}
+
+	// loop through each subdirectory (one per resource) and assemble
+	// catalog of items within it.
+	resources := map[string]*ResourceItems{}
+	for _, resourceDir := range resourceDirs {
+		if !resourceDir.IsDir() {
+			continue
+		}
+
+		resourceItems := &ResourceItems{
+			GroupResource:    resourceDir.Name(),
+			ItemsByNamespace: map[string][]string{},
+		}
+
+		// check for existence of a "cluster" subdirectory containing cluster-scoped
+		// instances of this resource, and read its contents if it exists.
+		clusterScopedDir := filepath.Join(resourcesDir, resourceDir.Name(), velerov1api.ClusterScopedDir)
+		exists, err := p.fs.DirExists(clusterScopedDir)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error checking for existence of directory %q", strings.TrimPrefix(clusterScopedDir, dir+"/"))
+		}
+		if exists {
+			items, err := p.getResourceItemsForScope(clusterScopedDir, dir)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(items) > 0 {
+				resourceItems.ItemsByNamespace[""] = items
+			}
+		}
+
+		// check for existence of a "namespaces" subdirectory containing further subdirectories,
+		// one per namespace, and read its contents if it exists.
+		namespaceScopedDir := filepath.Join(resourcesDir, resourceDir.Name(), velerov1api.NamespaceScopedDir)
+		exists, err = p.fs.DirExists(namespaceScopedDir)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error checking for existence of directory %q", strings.TrimPrefix(namespaceScopedDir, dir+"/"))
+		}
+		if exists {
+			namespaceDirs, err := p.fs.ReadDir(namespaceScopedDir)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading contents of directory %q", strings.TrimPrefix(namespaceScopedDir, dir+"/"))
+			}
+
+			for _, namespaceDir := range namespaceDirs {
+				if !namespaceDir.IsDir() {
+					continue
+				}
+
+				items, err := p.getResourceItemsForScope(filepath.Join(namespaceScopedDir, namespaceDir.Name()), dir)
+				if err != nil {
+					return nil, err
+				}
+
+				if len(items) > 0 {
+					resourceItems.ItemsByNamespace[namespaceDir.Name()] = items
+				}
+			}
+		}
+
+		resources[resourceDir.Name()] = resourceItems
+	}
+
+	return resources, nil
+}
+
+// getResourceItemsForScope returns the list of items with a namespace or
+// cluster-scoped subdirectory for a specific resource.
+func (p *Parser) getResourceItemsForScope(dir, archiveRootDir string) ([]string, error) {
+	files, err := p.fs.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading contents of directory %q", strings.TrimPrefix(dir, archiveRootDir+"/"))
+	}
+
+	var items []string
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		items = append(items, strings.TrimSuffix(file.Name(), ".json"))
+	}
+
+	return items, nil
+}

--- a/pkg/archive/parser_test.go
+++ b/pkg/archive/parser_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2019 the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/heptio/velero/pkg/test"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		dir     string
+		wantErr error
+		want    map[string]*ResourceItems
+	}{
+		{
+			name:    "when there is no top-level resources directory, an error is returned",
+			dir:     "root-dir",
+			wantErr: errors.New("directory \"resources\" does not exist"),
+		},
+		{
+			name:  "when there are no directories under the resources directory, an empty map is returned",
+			dir:   "root-dir",
+			files: []string{"root-dir/resources/"},
+			want:  map[string]*ResourceItems{},
+		},
+		{
+			name: "a mix of cluster-scoped and namespaced items across multiple resources are correctly returned",
+			dir:  "root-dir",
+			files: []string{
+				"root-dir/resources/widgets.foo/cluster/item-1.json",
+				"root-dir/resources/widgets.foo/cluster/item-2.json",
+				"root-dir/resources/widgets.foo/namespaces/ns-1/item-1.json",
+				"root-dir/resources/widgets.foo/namespaces/ns-1/item-2.json",
+				"root-dir/resources/widgets.foo/namespaces/ns-2/item-1.json",
+				"root-dir/resources/widgets.foo/namespaces/ns-2/item-2.json",
+
+				"root-dir/resources/dongles.foo/cluster/item-3.json",
+				"root-dir/resources/dongles.foo/cluster/item-4.json",
+
+				"root-dir/resources/dongles.bar/namespaces/ns-3/item-3.json",
+				"root-dir/resources/dongles.bar/namespaces/ns-3/item-4.json",
+				"root-dir/resources/dongles.bar/namespaces/ns-4/item-5.json",
+				"root-dir/resources/dongles.bar/namespaces/ns-4/item-6.json",
+			},
+			want: map[string]*ResourceItems{
+				"widgets.foo": {
+					GroupResource: "widgets.foo",
+					ItemsByNamespace: map[string][]string{
+						"":     {"item-1", "item-2"},
+						"ns-1": {"item-1", "item-2"},
+						"ns-2": {"item-1", "item-2"},
+					},
+				},
+				"dongles.foo": {
+					GroupResource: "dongles.foo",
+					ItemsByNamespace: map[string][]string{
+						"": {"item-3", "item-4"},
+					},
+				},
+				"dongles.bar": {
+					GroupResource: "dongles.bar",
+					ItemsByNamespace: map[string][]string{
+						"ns-3": {"item-3", "item-4"},
+						"ns-4": {"item-5", "item-6"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Parser{
+				fs: test.NewFakeFileSystem(),
+			}
+
+			for _, file := range tc.files {
+				require.NoError(t, p.fs.MkdirAll(file, 0755))
+
+				if !strings.HasSuffix(file, "/") {
+					res, err := p.fs.Create(file)
+					require.NoError(t, err)
+					require.NoError(t, res.Close())
+				}
+			}
+
+			res, err := p.Parse(tc.dir)
+			if tc.wantErr != nil {
+				assert.Equal(t, err.Error(), tc.wantErr.Error())
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.want, res)
+			}
+		})
+	}
+}

--- a/pkg/archive/parser_test.go
+++ b/pkg/archive/parser_test.go
@@ -94,7 +94,8 @@ func TestParse(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &Parser{
-				fs: test.NewFakeFileSystem(),
+				log: test.NewLogger(),
+				fs:  test.NewFakeFileSystem(),
 			}
 
 			for _, file := range tc.files {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -391,7 +391,7 @@ func (ctx *context) execute() (Result, Result) {
 	// need to set this for additionalItems to be restored
 	ctx.restoreDir = dir
 
-	backupResources, err := archive.NewParser(ctx.fileSystem).Parse(ctx.restoreDir)
+	backupResources, err := archive.NewParser(ctx.log, ctx.fileSystem).Parse(ctx.restoreDir)
 	if err != nil {
 		addVeleroError(&errs, errors.Wrap(err, "error parsing backup contents"))
 		return warnings, errs

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -696,7 +696,7 @@ func TestInvalidTarballContents(t *testing.T) {
 			tarball: newTarWriter(t).
 				done(),
 			wantErrs: Result{
-				Velero: []string{"backup does not contain top level resources directory"},
+				Velero: []string{"error parsing backup contents: directory \"resources\" does not exist"},
 			},
 		},
 		{


### PR DESCRIPTION
Still a WIP as I need to add/do some more testing and nail down some details, but wanted to share as-is for input.

I'm trying to continually do some simplification on `pkg/restore` where possible, and this seemed like an obvious incremental step. This takes logic around how to navigate a backup tarball as extracted to the local filesystem and encapsulates it in its own package for consumption by `pkg/restore.`