### PR TITLE
design doc template: remove status field

### DIFF
--- a/design/_template.md
+++ b/design/_template.md
@@ -1,7 +1,5 @@
 # Design proposal template (replace with your proposal's title)
 
-Status: {Draft,Accepted,Declined}
-
 One to two sentences that describes the goal of this proposal.
 The reader should be able to tell by the title, and the opening paragraph, if this document is relevant to them.
 


### PR DESCRIPTION
After discussing with the team, it doesn't make sense for all design proposals to have a draft/accepted status. Currently draft proposals can be kept open as PRs and all merged proposals are considered to be accepted. Removing the status field here removes the extra step of having to update the proposal status before merging.