### PR TITLE
Make GCP credentials parsing errors less ambiguous

### DIFF
--- a/pkg/cloudprovider/gcp/object_store.go
+++ b/pkg/cloudprovider/gcp/object_store.go
@@ -83,7 +83,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	}
 	jwtConfig, err := google.JWTConfigFromJSON(creds)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "error parsing credentials file; should be JSON")
 	}
 	if jwtConfig.Email == "" {
 		return errors.Errorf("credentials file pointed to by %s does not contain an email", credentialsEnvVar)


### PR DESCRIPTION
A user encountered the following error on a GCP project:

`An error occurred: some backup storage locations are invalid: error getting backup store for location "default": rpc error: code = Unknown desc = invalid character '-' in numeric literal`

This error was ambiguous and took some time to track down to the fact
that their credentials file wasn't a JSON file, but instead the contents
of the private key field. This change makes the problem slightly easier
to debug.

The error now looks like this:

`An error occurred: some backup storage locations are invalid: error getting backup store for location "default": rpc error: code = Unknown desc = error parsing credentials file; should be JSON: invalid character '-' in numeric literal`

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>