### PR TITLE
velero install: wait for restic daemonset to be ready

### DIFF
--- a/changelogs/unreleased/1859-skriss
+++ b/changelogs/unreleased/1859-skriss
@@ -1,0 +1,1 @@
+velero install: if `--use-restic` and `--wait` are specified, wait up to a minute for restic daemonset to be ready

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -238,9 +238,16 @@ func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	if o.Wait {
-		fmt.Println("Waiting for Velero to be ready.")
+		fmt.Println("Waiting for Velero deployment to be ready.")
 		if _, err = install.DeploymentIsReady(factory, o.Namespace); err != nil {
 			return errors.Wrap(err, errorMsg)
+		}
+
+		if o.UseRestic {
+			fmt.Println("Waiting for Velero restic daemonset to be ready.")
+			if _, err = install.DaemonSetIsReady(factory, o.Namespace); err != nil {
+				return errors.Wrap(err, errorMsg)
+			}
 		}
 	}
 	if o.SecretFile == "" {


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Closes #1716 

This is a copy-paste with modifications from the code that waits for the deployment to be ready. I looked again at the API docs for daemonsets, and I believe the readiness check I have makes the most sense -- comparing the number of expected scheduled pods to the number of "available" pods, which means pods on proper nodes that have been ready for `spec.minReadySeconds`. It seems like the Octant logic could falsely report "ready" if not all pods have been started yet.