### PR TITLE
Change restic prune default interval to 7d and make user-configurable

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -118,6 +118,7 @@ type serverConfig struct {
 	clientBurst                                                             int
 	profilerAddress                                                         string
 	formatFlag                                                              *logging.FormatFlag
+	defaultResticMaintenanceFrequency                                       time.Duration
 }
 
 type controllerRunInfo struct {
@@ -130,19 +131,20 @@ func NewCommand(f client.Factory) *cobra.Command {
 		volumeSnapshotLocations = flag.NewMap().WithKeyValueDelimiter(":")
 		logLevelFlag            = logging.LogLevelFlag(logrus.InfoLevel)
 		config                  = serverConfig{
-			pluginDir:                      "/plugins",
-			metricsAddress:                 defaultMetricsAddress,
-			defaultBackupLocation:          "default",
-			defaultVolumeSnapshotLocations: make(map[string]string),
-			backupSyncPeriod:               defaultBackupSyncPeriod,
-			defaultBackupTTL:               defaultBackupTTL,
-			podVolumeOperationTimeout:      defaultPodVolumeOperationTimeout,
-			restoreResourcePriorities:      defaultRestorePriorities,
-			clientQPS:                      defaultClientQPS,
-			clientBurst:                    defaultClientBurst,
-			profilerAddress:                defaultProfilerAddress,
-			resourceTerminatingTimeout:     defaultResourceTerminatingTimeout,
-			formatFlag:                     logging.NewFormatFlag(),
+			pluginDir:                         "/plugins",
+			metricsAddress:                    defaultMetricsAddress,
+			defaultBackupLocation:             "default",
+			defaultVolumeSnapshotLocations:    make(map[string]string),
+			backupSyncPeriod:                  defaultBackupSyncPeriod,
+			defaultBackupTTL:                  defaultBackupTTL,
+			podVolumeOperationTimeout:         defaultPodVolumeOperationTimeout,
+			restoreResourcePriorities:         defaultRestorePriorities,
+			clientQPS:                         defaultClientQPS,
+			clientBurst:                       defaultClientBurst,
+			profilerAddress:                   defaultProfilerAddress,
+			resourceTerminatingTimeout:        defaultResourceTerminatingTimeout,
+			formatFlag:                        logging.NewFormatFlag(),
+			defaultResticMaintenanceFrequency: restic.DefaultMaintenanceFrequency,
 		}
 	)
 
@@ -198,6 +200,7 @@ func NewCommand(f client.Factory) *cobra.Command {
 	command.Flags().StringVar(&config.profilerAddress, "profiler-address", config.profilerAddress, "the address to expose the pprof profiler")
 	command.Flags().DurationVar(&config.resourceTerminatingTimeout, "terminating-resource-timeout", config.resourceTerminatingTimeout, "how long to wait on persistent volumes and namespaces to terminate during a restore before timing out")
 	command.Flags().DurationVar(&config.defaultBackupTTL, "default-backup-ttl", config.defaultBackupTTL, "how long to wait by default before backups can be garbage collected")
+	command.Flags().DurationVar(&config.defaultResticMaintenanceFrequency, "default-restic-prune-frequency", config.defaultResticMaintenanceFrequency, "how often 'restic prune' is run for restic repositories by default")
 
 	return command
 }
@@ -689,6 +692,7 @@ func (s *server) runControllers(defaultVolumeSnapshotLocations map[string]string
 			s.veleroClient.VeleroV1(),
 			s.sharedInformerFactory.Velero().V1().BackupStorageLocations(),
 			s.resticManager,
+			s.config.defaultResticMaintenanceFrequency,
 		)
 
 		return controllerRunInfo{

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -18,6 +18,7 @@ package install
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -44,4 +45,8 @@ func TestDeployment(t *testing.T) {
 	deploy = Deployment("velero", WithSecret(true))
 	assert.Equal(t, 5, len(deploy.Spec.Template.Spec.Containers[0].Env))
 	assert.Equal(t, 3, len(deploy.Spec.Template.Spec.Volumes))
+
+	deploy = Deployment("velero", WithDefaultResticMaintenanceFrequency(24*time.Hour))
+	assert.Len(t, deploy.Spec.Template.Spec.Containers[0].Args, 2)
+	assert.Equal(t, "--default-restic-prune-frequency=24h0m0s", deploy.Spec.Template.Spec.Containers[0].Args[1])
 }

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package install
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -193,20 +195,21 @@ func appendUnstructured(list *unstructured.UnstructuredList, obj runtime.Object)
 }
 
 type VeleroOptions struct {
-	Namespace          string
-	Image              string
-	ProviderName       string
-	Bucket             string
-	Prefix             string
-	PodAnnotations     map[string]string
-	VeleroPodResources corev1.ResourceRequirements
-	ResticPodResources corev1.ResourceRequirements
-	SecretData         []byte
-	RestoreOnly        bool
-	UseRestic          bool
-	UseVolumeSnapshots bool
-	BSLConfig          map[string]string
-	VSLConfig          map[string]string
+	Namespace                         string
+	Image                             string
+	ProviderName                      string
+	Bucket                            string
+	Prefix                            string
+	PodAnnotations                    map[string]string
+	VeleroPodResources                corev1.ResourceRequirements
+	ResticPodResources                corev1.ResourceRequirements
+	SecretData                        []byte
+	RestoreOnly                       bool
+	UseRestic                         bool
+	UseVolumeSnapshots                bool
+	BSLConfig                         map[string]string
+	VSLConfig                         map[string]string
+	DefaultResticMaintenanceFrequency time.Duration
 }
 
 // AllResources returns a list of all resources necessary to install Velero, in the appropriate order, into a Kubernetes cluster.
@@ -245,20 +248,20 @@ func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
 
 	secretPresent := o.SecretData != nil
 
-	deploy := Deployment(o.Namespace,
+	deployOpts := []podTemplateOption{
 		WithAnnotations(o.PodAnnotations),
 		WithImage(o.Image),
 		WithResources(o.VeleroPodResources),
 		WithSecret(secretPresent),
-	)
-	if o.RestoreOnly {
-		deploy = Deployment(o.Namespace,
-			WithAnnotations(o.PodAnnotations),
-			WithImage(o.Image),
-			WithSecret(secretPresent),
-			WithRestoreOnly(),
-		)
+		WithDefaultResticMaintenanceFrequency(o.DefaultResticMaintenanceFrequency),
 	}
+
+	if o.RestoreOnly {
+		deployOpts = append(deployOpts, WithRestoreOnly())
+	}
+
+	deploy := Deployment(o.Namespace, deployOpts...)
+
 	appendUnstructured(resources, deploy)
 
 	if o.UseRestic {

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -43,8 +43,8 @@ const (
 	InitContainer = "restic-wait"
 
 	// DefaultMaintenanceFrequency is the default time interval
-	// at which restic check & prune are run.
-	DefaultMaintenanceFrequency = 24 * time.Hour
+	// at which restic prune is run.
+	DefaultMaintenanceFrequency = 7 * 24 * time.Hour
 
 	// PVCNameAnnotation is the key for the annotation added to
 	// pod volume backups when they're for a PVC.


### PR DESCRIPTION
Closes #1541 

This PR changes the default interval for running `restic prune` to 7d, and makes the default value user-configurable via flags on `velero server` and `velero install`.

I'm planning to include some instructions in the release notes on how to change existing repositories' maintenance intervals as well.