### PR TITLE
Add LD_LIBRARY_PATH as an env varible for the use of vsphere plugin

### DIFF
--- a/changelogs/unreleased/1893-lintongj
+++ b/changelogs/unreleased/1893-lintongj
@@ -1,0 +1,1 @@
+Add LD_LIBRARY_PATH (=/plugins) to the env variables of velero deployment.

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -162,7 +162,7 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 									},
 								},
 								{
-									Name: "LD_LIBRARY_PATH",
+									Name:  "LD_LIBRARY_PATH",
 									Value: "/plugins",
 								},
 							},

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -161,6 +161,10 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 										},
 									},
 								},
+								{
+									Name: "LD_LIBRARY_PATH",
+									Value: "/plugins",
+								},
 							},
 							Resources: c.resources,
 						},

--- a/pkg/install/deployment_test.go
+++ b/pkg/install/deployment_test.go
@@ -33,7 +33,7 @@ func TestDeployment(t *testing.T) {
 	assert.Equal(t, "--restore-only", deploy.Spec.Template.Spec.Containers[0].Args[1])
 
 	deploy = Deployment("velero", WithEnvFromSecretKey("my-var", "my-secret", "my-key"))
-	envSecret := deploy.Spec.Template.Spec.Containers[0].Env[2]
+	envSecret := deploy.Spec.Template.Spec.Containers[0].Env[3]
 	assert.Equal(t, "my-var", envSecret.Name)
 	assert.Equal(t, "my-secret", envSecret.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 	assert.Equal(t, "my-key", envSecret.ValueFrom.SecretKeyRef.Key)
@@ -43,7 +43,7 @@ func TestDeployment(t *testing.T) {
 	assert.Equal(t, corev1.PullIfNotPresent, deploy.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
 	deploy = Deployment("velero", WithSecret(true))
-	assert.Equal(t, 5, len(deploy.Spec.Template.Spec.Containers[0].Env))
+	assert.Equal(t, 6, len(deploy.Spec.Template.Spec.Containers[0].Env))
 	assert.Equal(t, 3, len(deploy.Spec.Template.Spec.Volumes))
 
 	deploy = Deployment("velero", WithDefaultResticMaintenanceFrequency(24*time.Hour))

--- a/site/docs/master/plugins.md
+++ b/site/docs/master/plugins.md
@@ -82,6 +82,10 @@ Velero will pass any known features flags as a comma-separated list of strings t
 
 Once parsed into a `[]string`, the features can then be registered using the `NewFeatureFlagSet` function and queried with `features.Enabled(<featureName>)`.
 
+## Environment Variables
+
+Velero adds the `LD_LIBRARY_PATH` into the list of environment variables to provide the convenience for plugins that requires C libraries/extensions in the runtime.
+
 [1]: https://github.com/heptio/velero-plugin-example
 [2]: https://github.com/heptio/velero/blob/master/pkg/plugin/logger.go
 [3]: https://github.com/heptio/velero/blob/master/pkg/restore/restic_restore_action.go


### PR DESCRIPTION
Hi folks,

We are working on the vSphere plugin for velero. To enable the data path of backup and restore using VDDK API, VDDK libraries need to be dynamically linked in the run time. Hence, we plan to copy required libraries to the directory /plugins in velero pod container and propose to add the env variable, LD_LIBRARY_PATH, to /plugins. Feel free to suggest any better alternatives.

Best,
Lintong