### PR TITLE
Increment logging for item backupper

### DIFF
--- a/changelogs/unreleased/1904-spiffcs
+++ b/changelogs/unreleased/1904-spiffcs
@@ -1,0 +1,1 @@
+Add check to update resource field during backupItem

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -120,9 +120,7 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 
 	log := logger.WithField("name", name)
 	log = log.WithField("resource", groupResource)
-	if namespace != "" {
-		log = log.WithField("namespace", namespace)
-	}
+	log = log.WithField("namespace", namespace)
 
 	if metadata.GetLabels()["velero.io/exclude-from-backup"] == "true" {
 		log.Info("Excluding item because it has label velero.io/exclude-from-backup=true")

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -116,20 +115,11 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 		return err
 	}
 
-	typedata, err := meta.TypeAccessor(obj)
-	if err != nil {
-		return err
-	}
-
 	namespace := metadata.GetNamespace()
 	name := metadata.GetName()
-	resource := strings.ToLower(typedata.GetKind())
 
 	log := logger.WithField("name", name)
-	if resource != groupResource.Resource {
-		log = log.WithField("resource", resource)
-	}
-
+	log = log.WithField("resource", groupResource)
 	if namespace != "" {
 		log = log.WithField("namespace", namespace)
 	}

--- a/pkg/backup/item_backupper.go
+++ b/pkg/backup/item_backupper.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -115,10 +116,20 @@ func (ib *defaultItemBackupper) backupItem(logger logrus.FieldLogger, obj runtim
 		return err
 	}
 
+	typedata, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return err
+	}
+
 	namespace := metadata.GetNamespace()
 	name := metadata.GetName()
+	resource := strings.ToLower(typedata.GetKind())
 
 	log := logger.WithField("name", name)
+	if resource != groupResource.Resource {
+		log = log.WithField("resource", resource)
+	}
+
 	if namespace != "" {
 		log = log.WithField("namespace", namespace)
 	}


### PR DESCRIPTION
Fixes #1844 

I've added logic to the `backupItem` function.

If the `Kind` of the object passed in is different from the `APIResource.Name` set in the `backupResource` function then logging is updated to make it more clear what is being backed up.

I can always update this to incorporate the parent field as suggested in #1844 

![Screen Shot 2019-09-24 at 7 18 56 AM](https://user-images.githubusercontent.com/32073428/65507285-9b669800-de9b-11e9-9af6-511d4b781d1f.png)

Signed-off-by: Christopher Phillips <cphillips918@gmail.com>