### PR TITLE
Use layers in the builder Dockerfile

### DIFF
--- a/hack/build-image/Dockerfile
+++ b/hack/build-image/Dockerfile
@@ -14,30 +14,31 @@
 
 FROM golang:1.12
 
-RUN mkdir -p /go/src/k8s.io && \
-    cd /go/src/k8s.io && \
-    git config --global advice.detachedHead false && \
-    git clone -b kubernetes-1.15.3 https://github.com/kubernetes/code-generator && \
-    git clone -b kubernetes-1.15.3 https://github.com/kubernetes/apimachinery && \
-    # vendor code-generator go modules to be compatible with pre-1.15
-    cd /go/src/k8s.io/code-generator && GO111MODULE=on go mod vendor && \
-    go get -d sigs.k8s.io/controller-tools/cmd/controller-gen && \
-    cd /go/src/sigs.k8s.io/controller-tools && GO111MODULE=on go mod vendor && \
-    go get golang.org/x/tools/cmd/goimports && \
-    cd /go/src/golang.org/x/tools && \
-    git checkout 40a48ad93fbe707101afb2099b738471f70594ec && \
-    go install ./cmd/goimports && \
-    echo chmod -R a+w /go && \
-    # download & install protoc
-    apt-get update && apt-get install -y unzip && \
-    wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip && \
+RUN mkdir -p /go/src/k8s.io
+WORKDIR /go/src/k8s.io
+RUN git config --global advice.detachedHead false
+RUN git clone -b kubernetes-1.15.3 https://github.com/kubernetes/code-generator
+RUN git clone -b kubernetes-1.15.3 https://github.com/kubernetes/apimachinery 
+# vendor code-generator go modules to be compatible with pre-1.15
+WORKDIR  /go/src/k8s.io/code-generator
+# Don't use ENV here because we don't want to disable modules for subsequent commands
+RUN GO111MODULE=on go mod vendor
+RUN go get -d sigs.k8s.io/controller-tools/cmd/controller-gen
+WORKDIR /go/src/sigs.k8s.io/controller-tools
+RUN GO111MODULE=on go mod vendor
+RUN go get golang.org/x/tools/cmd/goimports
+WORKDIR /go/src/golang.org/x/tools
+RUN git checkout 40a48ad93fbe707101afb2099b738471f70594ec
+RUN go install ./cmd/goimports
+RUN echo chmod -R a+w /go
+WORKDIR /root
+RUN apt-get update && apt-get install -y unzip
+RUN wget --quiet https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip && \
     unzip protoc-3.9.1-linux-x86_64.zip && \
     mv bin/protoc /usr/bin/protoc && \
-    chmod +x /usr/bin/protoc && \
-    # download & install protoc-gen-go plugin (v1.0.0)
-    mkdir -p /go/src/github.com/golang && \
-    cd /go/src/github.com/golang && \
-    git config --global advice.detachedHead false && \
-    git clone -b v1.0.0 https://github.com/golang/protobuf && \
-    cd /go/src/github.com/golang/protobuf && \
-    go install ./protoc-gen-go
+    chmod +x /usr/bin/protoc
+RUN mkdir -p /go/src/github.com/golang
+WORKDIR /go/src/github.com/golang
+RUN git clone -b v1.0.0 https://github.com/golang/protobuf
+WORKDIR /go/src/github.com/golang/protobuf
+RUN go install ./protoc-gen-go


### PR DESCRIPTION
Using layers can simplify iteration on the builder image itself, and
shorten build times when only one command is changed.

This change was inspired by a [a discussion on Slack](https://kubernetes.slack.com/archives/C6VCGP4MT/p1568840299076900). 

I've also timed the previous version compared to this one with `time make` - it's roughly equivalent once built and retrieve from cache. However, each time the older version has to be updated, it reruns all commands. This new version does not.

Old:
make  2.28s user 0.53s system 1% cpu 2:25.84 total
make  2.19s user 0.51s system 38% cpu 6.946 total
make  2.25s user 0.51s system 40% cpu 6.740 total
make  2.31s user 0.50s system 39% cpu 7.060 total

New:
make  2.27s user 0.50s system 5% cpu 51.654 total
make  2.23s user 0.48s system 37% cpu 7.225 total
make  2.23s user 0.48s system 38% cpu 6.992 total
make  2.24s user 0.48s system 36% cpu 7.387 total

Signed-off-by: Nolan Brubaker <brubakern@vmware.com>