### PR TITLE
Fix for #1888: check item's original namespace, not remapped one, for inclusion/exclusion

### DIFF
--- a/changelogs/unreleased/1909-skriss
+++ b/changelogs/unreleased/1909-skriss
@@ -1,0 +1,1 @@
+bug fix: during restore, check item's original namespace, not the remapped one, for inclusion/exclusion

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -751,9 +751,11 @@ func (ctx *context) restoreItem(obj *unstructured.Unstructured, groupResource sc
 	// Check if namespace/cluster-scoped resource should be restored. We need
 	// to do this here since this method may be getting called for an additional
 	// item which is in a namespace that's excluded, or which is cluster-scoped
-	// and should be excluded.
+	// and should be excluded. Note that we're checking the object's namespace (
+	// via obj.GetNamespace()) instead of the namespace parameter, because we want
+	// to check the *original* namespace, not the remapped one if it's been remapped.
 	if namespace != "" {
-		if !ctx.namespaceIncludesExcludes.ShouldInclude(namespace) {
+		if !ctx.namespaceIncludesExcludes.ShouldInclude(obj.GetNamespace()) {
 			ctx.log.WithFields(logrus.Fields{
 				"namespace":     obj.GetNamespace(),
 				"name":          obj.GetName(),

--- a/pkg/restore/restore_test.go
+++ b/pkg/restore/restore_test.go
@@ -562,6 +562,24 @@ func TestRestoreNamespaceMapping(t *testing.T) {
 				test.Pods(): {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2", "ns-3/pod-3"},
 			},
 		},
+		{
+			name:    "namespace mappings are applied when IncludedNamespaces are specified",
+			restore: defaultRestore().IncludedNamespaces("ns-1", "ns-2").NamespaceMappings("ns-1", "mapped-ns-1", "ns-2", "mapped-ns-2").Result(),
+			backup:  defaultBackup().Result(),
+			apiResources: []*test.APIResource{
+				test.Pods(),
+			},
+			tarball: newTarWriter(t).
+				addItems("pods",
+					builder.ForPod("ns-1", "pod-1").Result(),
+					builder.ForPod("ns-2", "pod-2").Result(),
+					builder.ForPod("ns-3", "pod-3").Result(),
+				).
+				done(),
+			want: map[*test.APIResource][]string{
+				test.Pods(): {"mapped-ns-1/pod-1", "mapped-ns-2/pod-2"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #1888 

cc @betta1 - would be great if you could test this out!  I can push an image if you need.